### PR TITLE
Add data ingestion utilities

### DIFF
--- a/src/echopress/__init__.py
+++ b/src/echopress/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level package for echopress."""
+
+__all__ = ["ingest"]

--- a/src/echopress/ingest/__init__.py
+++ b/src/echopress/ingest/__init__.py
@@ -1,0 +1,14 @@
+"""Utility modules for ingesting EchoPress datasets."""
+
+from .pstream import read_pstream, PStreamRecord, parse_timestamp
+from .ostream import load_ostream, OStream
+from .indexer import DatasetIndexer
+
+__all__ = [
+    "read_pstream",
+    "PStreamRecord",
+    "parse_timestamp",
+    "load_ostream",
+    "OStream",
+    "DatasetIndexer",
+]

--- a/src/echopress/ingest/indexer.py
+++ b/src/echopress/ingest/indexer.py
@@ -1,0 +1,83 @@
+"""Dataset indexer utilities.
+
+The :class:`DatasetIndexer` class walks a dataset directory and builds
+registries of available P-stream and O-stream files.  The indexer is
+agnostic to the exact dataset layout; it simply records files matching
+expected suffixes and exposes lookup helpers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+PSTREAM_EXTENSIONS = {".pstream", ".p", ".ps"}
+OSTREAM_EXTENSIONS = {".ostream", ".o", ".os", ".npz", ".json"}
+
+
+def _session_id(path: Path) -> str:
+    """Derive a session identifier from ``path``.
+
+    The default strategy uses the stem (basename without extensions).
+    """
+    return path.stem
+
+
+@dataclass
+class DatasetIndexer:
+    """Index of dataset files on disk."""
+
+    root: Path
+    pstreams: Dict[str, List[Path]] = field(default_factory=dict)
+    ostreams: Dict[str, List[Path]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.root = Path(self.root)
+        self.scan()
+
+    # ------------------------------------------------------------------
+    def scan(self) -> None:
+        """Walk the dataset tree and populate the registries."""
+        self.pstreams.clear()
+        self.ostreams.clear()
+
+        for path in self.root.rglob("*"):
+            if not path.is_file():
+                continue
+            suffix = path.suffix.lower()
+            sid = _session_id(path)
+            if suffix in PSTREAM_EXTENSIONS:
+                self.pstreams.setdefault(sid, []).append(path)
+            elif suffix in OSTREAM_EXTENSIONS:
+                self.ostreams.setdefault(sid, []).append(path)
+
+    # ------------------------------------------------------------------
+    def sessions(self) -> List[str]:
+        """Return the session identifiers known to the indexer."""
+        return sorted(set(self.pstreams) | set(self.ostreams))
+
+    def get_pstreams(self, session_id: str) -> List[Path]:
+        """Return P-stream files for ``session_id`` (possibly empty)."""
+        return self.pstreams.get(session_id, [])
+
+    def get_ostreams(self, session_id: str) -> List[Path]:
+        """Return O-stream files for ``session_id`` (possibly empty)."""
+        return self.ostreams.get(session_id, [])
+
+    def first_pstream(self, session_id: str) -> Optional[Path]:
+        """Convenience method returning the first P-stream file for a session."""
+        files = self.get_pstreams(session_id)
+        return files[0] if files else None
+
+    def first_ostream(self, session_id: str) -> Optional[Path]:
+        """Convenience method returning the first O-stream file for a session."""
+        files = self.get_ostreams(session_id)
+        return files[0] if files else None
+
+    # ------------------------------------------------------------------
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return (
+            f"DatasetIndexer(root={self.root!r}, "
+            f"pstreams={len(self.pstreams)}, ostreams={len(self.ostreams)})"
+        )

--- a/src/echopress/ingest/ostream.py
+++ b/src/echopress/ingest/ostream.py
@@ -1,0 +1,68 @@
+"""Parser for O-stream files.
+
+O-streams typically contain multi-channel observation arrays, per-sample
+timestamps and metadata such as session identifiers.  This module provides
+:func:`load_ostream` to load these files into the :class:`OStream` data class.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any
+import json
+
+import numpy as np
+
+
+@dataclass
+class OStream:
+    """In-memory representation of an O-stream."""
+
+    session_id: str
+    timestamps: np.ndarray
+    channels: np.ndarray
+    meta: Dict[str, Any]
+
+
+def load_ostream(path: str | Path) -> OStream:
+    """Load an O-stream file.
+
+    The loader understands two simple file formats:
+
+    - ``.npz`` archives containing ``session_id``, ``timestamps`` and
+      ``channels`` arrays, plus optional additional metadata arrays.
+    - JSON files with the same keys.
+
+    Additional arrays or key/value pairs are preserved in the ``meta``
+    dictionary of the returned :class:`OStream` instance.
+    """
+    path = Path(path)
+    if path.suffix == ".npz":
+        data = np.load(path, allow_pickle=True)
+        session_id = (
+            data["session_id"].item() if "session_id" in data else path.stem
+        )
+        timestamps = np.asarray(data.get("timestamps", []), dtype=float)
+        channels = np.asarray(data.get("channels", []), dtype=float)
+        meta = {
+            key: data[key]
+            for key in data.files
+            if key not in {"session_id", "timestamps", "channels"}
+        }
+        return OStream(session_id=session_id, timestamps=timestamps, channels=channels, meta=meta)
+
+    if path.suffix in {".json", ".ndjson", ".txt"}:
+        with open(path, "r", encoding="utf8") as fh:
+            obj = json.load(fh)
+        session_id = obj.get("session_id", path.stem)
+        timestamps = np.asarray(obj.get("timestamps", []), dtype=float)
+        channels = np.asarray(obj.get("channels", []), dtype=float)
+        meta = {
+            key: value
+            for key, value in obj.items()
+            if key not in {"session_id", "timestamps", "channels"}
+        }
+        return OStream(session_id=session_id, timestamps=timestamps, channels=channels, meta=meta)
+
+    raise ValueError(f"Unsupported O-stream file format: {path.suffix}")

--- a/src/echopress/ingest/pstream.py
+++ b/src/echopress/ingest/pstream.py
@@ -1,0 +1,103 @@
+"""Parser for P-stream files.
+
+P-streams provide sequences of pressure measurements ``p`` together with
+associated timestamps ``T^P``.  The :func:`read_pstream` generator yields
+records as :class:`PStreamRecord` objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterator, Union, TextIO
+import pathlib
+import re
+
+# Regular expression recognising the timestamp grammar.  The grammar is
+# intentionally permissive in order to interoperate with a variety of
+# datasets.  It accepts ISO-8601 strings, ``HH:MM:SS`` strings and plain
+# floating point seconds since the Unix epoch.
+TIMESTAMP_RE = re.compile(
+    r"""^\s*
+        (?:
+            (?P<iso>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)
+            |
+            (?P<hms>\d{2}:\d{2}:\d{2}(?:\.\d+)?)
+            |
+            (?P<float>\d+(?:\.\d+)?)
+        )
+        \s*$""",
+    re.VERBOSE,
+)
+
+
+def parse_timestamp(token: str) -> datetime:
+    """Parse a timestamp token.
+
+    Parameters
+    ----------
+    token:
+        String representation of a timestamp.  Supported forms include
+        ISO-8601 date/time strings, ``HH:MM:SS[.ffffff]`` strings and
+        numeric seconds since the Unix epoch.
+    """
+    m = TIMESTAMP_RE.match(token)
+    if not m:
+        raise ValueError(f"Unrecognised timestamp: {token!r}")
+
+    if m.group("iso"):
+        iso = m.group("iso").replace("Z", "+00:00")
+        return datetime.fromisoformat(iso)
+
+    if m.group("hms"):
+        fmt = "%H:%M:%S.%f" if "." in m.group("hms") else "%H:%M:%S"
+        today = datetime.now(timezone.utc).date()
+        return datetime.combine(
+            today, datetime.strptime(m.group("hms"), fmt).time(), tzinfo=timezone.utc
+        )
+
+    return datetime.fromtimestamp(float(m.group("float")), tz=timezone.utc)
+
+
+@dataclass
+class PStreamRecord:
+    """Representation of a single P-stream record."""
+
+    timestamp: datetime
+    pressure: float
+
+
+def _parse_line(line: str) -> PStreamRecord | None:
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+
+    if "," in line:
+        ts_str, p_str, *_ = line.split(",")
+    else:
+        ts_str, p_str, *_ = line.split()
+
+    timestamp = parse_timestamp(ts_str)
+    pressure = float(p_str)
+    return PStreamRecord(timestamp, pressure)
+
+
+def read_pstream(path: Union[str, pathlib.Path, TextIO]) -> Iterator[PStreamRecord]:
+    """Yield records from a P-stream file.
+
+    Parameters
+    ----------
+    path:
+        Either a path-like object or a text file object providing lines.
+    """
+    if isinstance(path, (str, pathlib.Path)):
+        with open(path, "r", encoding="utf8") as fh:
+            for line in fh:
+                record = _parse_line(line)
+                if record is not None:
+                    yield record
+    else:
+        for line in path:
+            record = _parse_line(line)
+            if record is not None:
+                yield record


### PR DESCRIPTION
## Summary
- Add pstream parser that reads `(T^P, p)` records via flexible timestamp grammar
- Add ostream loader that extracts session metadata, timestamps, and channels from NPZ or JSON
- Introduce dataset indexer to catalog P- and O-stream files and provide lookup helpers

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae472c9cc48322ad3307dbdcf5a64d