### PR TITLE
Add visualization helpers and CLI plotting tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/viz/helpers.py
+++ b/viz/helpers.py
@@ -1,0 +1,41 @@
+"""Utility helpers for plotting and data loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def load_array(path: str | Path) -> np.ndarray:
+    """Load a 1D numeric array from ``path``.
+
+    ``.npy`` files are loaded with :func:`numpy.load` while any other extension
+    is treated as a text file with comma separated values.
+    """
+    p = Path(path)
+    if p.suffix == ".npy":
+        return np.load(p)
+    return np.loadtxt(p, delimiter=",")
+
+
+def plot_series(ax: plt.Axes, series: Sequence[float], label: str | None = None, **kwargs) -> None:
+    """Plot a 1D series on ``ax`` with an optional label."""
+    ax.plot(series, label=label, **kwargs)
+    if label:
+        ax.legend()
+
+
+def save_or_show(fig: plt.Figure, save: str | Path | None = None, show: bool = False) -> None:
+    """Save ``fig`` to ``save`` or display it interactively.
+
+    If ``save`` is ``None`` the figure will only be shown when ``show`` is
+    True.  When both are unset the figure is shown by default to give quick
+    feedback during inspection.
+    """
+    if save:
+        fig.savefig(save, bbox_inches="tight")
+    if show or not save:
+        plt.show()

--- a/viz/plot_adapter.py
+++ b/viz/plot_adapter.py
@@ -1,0 +1,44 @@
+"""Plot input signals and their adapter outputs."""
+
+from __future__ import annotations
+
+import argparse
+import matplotlib.pyplot as plt
+
+from .helpers import load_array, plot_series, save_or_show
+from .styles import apply_style
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Visualise adapter outputs")
+    parser.add_argument("--input", required=True, help="Path to the input signal")
+    parser.add_argument("--output", required=True, help="Path to the adapter output signal")
+    parser.add_argument("--save", help="Path to save the figure")
+    parser.add_argument("--show", action="store_true", help="Display the figure interactively")
+    args = parser.parse_args()
+
+    inp = load_array(args.input)
+    out = load_array(args.output)
+    n = min(len(inp), len(out))
+    inp = inp[:n]
+    out = out[:n]
+
+    diff = out - inp
+
+    apply_style()
+    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+
+    plot_series(ax1, inp, label="input")
+    plot_series(ax1, out, label="adapter output")
+    ax1.set_ylabel("Amplitude")
+    ax1.set_title("Input vs adapter output")
+
+    plot_series(ax2, diff, label="difference")
+    ax2.set_xlabel("Sample")
+    ax2.set_ylabel("Delta")
+
+    save_or_show(fig, args.save, args.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/viz/plot_alignment.py
+++ b/viz/plot_alignment.py
@@ -1,0 +1,44 @@
+"""Plot reference and aligned signals as well as their difference."""
+
+from __future__ import annotations
+
+import argparse
+import matplotlib.pyplot as plt
+
+from .helpers import load_array, plot_series, save_or_show
+from .styles import apply_style
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Visualise alignment between two signals")
+    parser.add_argument("--reference", required=True, help="Path to the reference signal")
+    parser.add_argument("--aligned", required=True, help="Path to the aligned signal")
+    parser.add_argument("--save", help="Path to save the figure")
+    parser.add_argument("--show", action="store_true", help="Display the figure interactively")
+    args = parser.parse_args()
+
+    ref = load_array(args.reference)
+    ali = load_array(args.aligned)
+    n = min(len(ref), len(ali))
+    ref = ref[:n]
+    ali = ali[:n]
+
+    diff = ali - ref
+
+    apply_style()
+    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+
+    plot_series(ax1, ref, label="reference")
+    plot_series(ax1, ali, label="aligned")
+    ax1.set_ylabel("Amplitude")
+    ax1.set_title("Reference vs aligned")
+
+    plot_series(ax2, diff, label="difference")
+    ax2.set_xlabel("Sample")
+    ax2.set_ylabel("Delta")
+
+    save_or_show(fig, args.save, args.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/viz/plot_signals.py
+++ b/viz/plot_signals.py
@@ -1,0 +1,39 @@
+"""Plot raw signal arrays from the command line."""
+
+from __future__ import annotations
+
+import argparse
+import matplotlib.pyplot as plt
+
+from .helpers import load_array, plot_series, save_or_show
+from .styles import apply_style
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plot one or more raw signals")
+    parser.add_argument("signals", nargs="+", help="Paths to signal arrays (.npy or .csv)")
+    parser.add_argument("--labels", nargs="*", help="Optional labels for each signal")
+    parser.add_argument("--save", help="Path to save the figure")
+    parser.add_argument("--show", action="store_true", help="Display the figure interactively")
+    args = parser.parse_args()
+
+    if args.labels and len(args.labels) != len(args.signals):
+        parser.error("Number of labels must match number of signals")
+
+    apply_style()
+    fig, ax = plt.subplots()
+
+    labels = args.labels or [None] * len(args.signals)
+    for path, label in zip(args.signals, labels):
+        data = load_array(path)
+        plot_series(ax, data, label=label)
+
+    ax.set_title("Raw signals")
+    ax.set_xlabel("Sample")
+    ax.set_ylabel("Amplitude")
+
+    save_or_show(fig, args.save, args.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/viz/styles.py
+++ b/viz/styles.py
@@ -1,0 +1,31 @@
+"""Matplotlib styles for echpressure2 visualisations."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+
+# Base style configuration used across all plots.  The values can be
+# overridden by supplying a different style mapping to :func:`apply_style`.
+BASE_STYLE = {
+    "figure.figsize": (10, 4),
+    "axes.grid": True,
+    "grid.linestyle": "--",
+    "grid.alpha": 0.5,
+    "axes.titlesize": "large",
+    "axes.labelsize": "medium",
+    "lines.linewidth": 1.5,
+}
+
+
+def apply_style(extra: dict | None = None) -> None:
+    """Apply a consistent matplotlib style.
+
+    Parameters
+    ----------
+    extra:
+        Optional dictionary of rcParams that override the base style.
+    """
+    style = BASE_STYLE.copy()
+    if extra:
+        style.update(extra)
+    plt.rcParams.update(style)


### PR DESCRIPTION
## Summary
- add `viz` package with shared `styles` and `helpers`
- introduce `plot_signals`, `plot_alignment`, and `plot_adapter` scripts for inspecting raw, aligned, and adapted signals
- provide CLI options for saving or showing plots

## Testing
- `python -m py_compile viz/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae476d5e3c83228295fdbf586a28a1