### PR TITLE
Add calibration and mapping utilities with configuration hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/src/echopress/__init__.py
+++ b/src/echopress/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for echopress."""

--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -1,0 +1,101 @@
+"""Configuration handling for the :mod:`echopress` package.
+
+The project makes heavy use of tunable parameters for calibration and
+mapping.  This module provides a small dataclass describing those
+parameters and helper functions to populate the configuration from
+environment variables.  All parameters have reasonable defaults so the
+module can be used without any external configuration, while still
+allowing users to override values at runtime by setting environment
+variables with the ``ECHOPRESS_`` prefix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+import os
+
+
+@dataclass
+class EchoPressConfig:
+    """Container for user configurable parameters.
+
+    Attributes
+    ----------
+    alpha, beta:
+        Lists of calibration coefficients such that
+        ``pressure = alpha[k] * voltage + beta[k]`` for channel ``k``.
+    scalar_channel:
+        Default channel index used when a scalar voltage value is
+        supplied to the calibration routine.
+    O_max:
+        Maximum allowed absolute alignment error when mapping the
+        streams.  ``None`` disables the check.
+    tie_break:
+        Strategy for resolving ties when multiple P-stream timestamps are
+        equally close to an O-stream midpoint.  Supported values are
+        ``"nearest"`` (first match), ``"first"`` and ``"last"``.
+    window_size:
+        Number of neighbouring timestamps in the P-stream to consider
+        when searching for the closest match.
+    kappa:
+        Multiplicative factor applied to the alignment error ``E_align``.
+    """
+
+    alpha: List[float] = field(default_factory=list)
+    beta: List[float] = field(default_factory=list)
+    scalar_channel: int = 0
+    O_max: Optional[float] = None
+    tie_break: str = "nearest"
+    window_size: int = 5
+    kappa: float = 1.0
+
+
+ENV_PREFIX = "ECHOPRESS_"
+
+
+def _get_env_list(name: str) -> List[float]:
+    value = os.getenv(ENV_PREFIX + name)
+    if not value:
+        return []
+    return [float(v) for v in value.split(",") if v]
+
+
+def load_config() -> EchoPressConfig:
+    """Create a configuration instance populated from environment variables."""
+    cfg = EchoPressConfig()
+    alpha = _get_env_list("ALPHA")
+    beta = _get_env_list("BETA")
+    if alpha:
+        cfg.alpha = alpha
+    if beta:
+        cfg.beta = beta
+
+    if (scalar := os.getenv(ENV_PREFIX + "SCALAR_CHANNEL")) is not None:
+        cfg.scalar_channel = int(scalar)
+    if (o_max := os.getenv(ENV_PREFIX + "O_MAX")) is not None:
+        cfg.O_max = float(o_max)
+    if (tie := os.getenv(ENV_PREFIX + "TIE_BREAK")) is not None:
+        cfg.tie_break = tie
+    if (window := os.getenv(ENV_PREFIX + "WINDOW_SIZE")) is not None:
+        cfg.window_size = int(window)
+    if (kappa := os.getenv(ENV_PREFIX + "KAPPA")) is not None:
+        cfg.kappa = float(kappa)
+    return cfg
+
+
+_default_config: Optional[EchoPressConfig] = None
+
+
+def get_config() -> EchoPressConfig:
+    """Return the module level configuration instance.
+
+    The configuration is loaded on first use and cached subsequently.  A
+    copy of the configuration can be obtained by calling :func:`load_config`
+    directly if isolation is desired.
+    """
+
+    global _default_config
+    if _default_config is None:
+        _default_config = load_config()
+    return _default_config

--- a/src/echopress/core/__init__.py
+++ b/src/echopress/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core algorithms for echopress."""

--- a/src/echopress/core/calibration.py
+++ b/src/echopress/core/calibration.py
@@ -1,0 +1,58 @@
+"""Voltage to pressure calibration routines."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Union
+
+from ..config import get_config
+
+Number = Union[int, float]
+
+
+def _apply_linear(v: Number, a: Number, b: Number) -> Number:
+    """Apply a simple linear transform."""
+    return a * v + b
+
+
+def calibrate(
+    voltage: Union[Number, Sequence[Number]],
+    channel: int | None = None,
+    *,
+    alpha: Sequence[Number] | None = None,
+    beta: Sequence[Number] | None = None,
+) -> Union[Number, list[Number]]:
+    """Map voltages to pressure values using calibration coefficients.
+
+    Parameters
+    ----------
+    voltage:
+        Voltage reading or sequence of readings.
+    channel:
+        Channel index.  If omitted, :mod:`echopress`' configuration
+        ``scalar_channel`` setting is used.
+    alpha, beta:
+        Optional explicit coefficient sequences overriding the configured
+        values.
+
+    Returns
+    -------
+    pressure:
+        A single calibrated pressure value or a list of values matching
+        the input sequence.
+    """
+
+    cfg = get_config()
+    alpha = list(alpha) if alpha is not None else cfg.alpha
+    beta = list(beta) if beta is not None else cfg.beta
+    if channel is None:
+        channel = cfg.scalar_channel
+
+    try:
+        a = alpha[channel]
+        b = beta[channel]
+    except IndexError as exc:  # pragma: no cover - defensive branch
+        raise ValueError("Channel index out of range") from exc
+
+    if isinstance(voltage, Iterable) and not isinstance(voltage, (str, bytes)):
+        return [_apply_linear(v, a, b) for v in voltage]
+    return _apply_linear(voltage, a, b)

--- a/src/echopress/core/mapping.py
+++ b/src/echopress/core/mapping.py
@@ -1,0 +1,85 @@
+"""Alignment algorithms for pressure and optical streams."""
+
+from __future__ import annotations
+
+from bisect import bisect_left
+from math import sqrt
+from typing import Iterable, List, Sequence, Tuple
+
+from ..config import get_config, EchoPressConfig
+
+
+Timestamp = float
+Interval = Tuple[Timestamp, Timestamp]
+
+
+def _resolve_tie(candidates: List[Tuple[float, int]], tie_break: str) -> int:
+    """Resolve tie between candidates based on configuration."""
+    candidates.sort(key=lambda x: (x[0], x[1]))
+    min_dist = candidates[0][0]
+    matches = [idx for dist, idx in candidates if abs(dist - min_dist) < 1e-12]
+    if tie_break == "last":
+        return matches[-1]
+    # Default to "first" behaviour
+    return matches[0]
+
+
+def align_streams(
+    p_times: Sequence[Timestamp],
+    o_intervals: Sequence[Interval],
+    *,
+    config: EchoPressConfig | None = None,
+) -> Tuple[List[int], float]:
+    """Align an optical stream to a pressure stream.
+
+    Parameters
+    ----------
+    p_times:
+        Monotonically increasing timestamps for the pressure stream.
+    o_intervals:
+        Sequence of ``(start, end)`` tuples representing optical samples.
+    config:
+        Optional explicit configuration instance.  When omitted the
+        module level configuration is used.
+
+    Returns
+    -------
+    indices, E_align:
+        ``indices`` contains, for each optical sample, the index of the
+        nearest pressure timestamp.  ``E_align`` is the root mean square
+        alignment error after applying the optional ``kappa`` multiplier.
+    """
+
+    cfg = config or get_config()
+    if not p_times:
+        raise ValueError("P-stream timestamps required")
+
+    # Precompute P-stream for efficient searching
+    p_times = list(p_times)
+    o_mid = [(s + e) / 2 for s, e in o_intervals]
+
+    indices: List[int] = []
+    errors: List[float] = []
+    prev_idx = 0
+    for m in o_mid:
+        search_lo = max(0, prev_idx - cfg.window_size)
+        search_hi = min(len(p_times), prev_idx + cfg.window_size + 1)
+        i = bisect_left(p_times, m, lo=search_lo, hi=search_hi)
+        # Gather candidate neighbours
+        cand: List[Tuple[float, int]] = []
+        for idx in range(max(search_lo, i - 1), min(search_hi, i + 1)):
+            cand.append((abs(p_times[idx] - m), idx))
+        chosen = _resolve_tie(cand, cfg.tie_break)
+        diff = p_times[chosen] - m
+        if cfg.O_max is not None and abs(diff) > cfg.O_max:
+            raise ValueError("O_max exceeded during alignment")
+        indices.append(chosen)
+        errors.append(diff)
+        prev_idx = chosen
+
+    if errors:
+        mse = sum(e * e for e in errors) / len(errors)
+        e_align = cfg.kappa * sqrt(mse)
+    else:
+        e_align = 0.0
+    return indices, e_align


### PR DESCRIPTION
## Summary
- add configuration module exposing alpha/beta coefficients, scalar channel, O_max, tie-break behaviour, window size and kappa multiplier
- implement calibration routine converting voltages to pressure using configured coefficients
- implement stream mapping utility aligning optical midpoints to pressure timestamps and computing E_align

## Testing
- `python -m py_compile $(find src -name '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae473742e08322b189f5204f52db33