### PR TITLE
Add derivative and uncertainty unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "echpressure2"
+version = "0.0.0"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_derivative.py
+++ b/tests/test_derivative.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+
+from core import central_difference, local_linear, savgol
+
+
+@pytest.mark.parametrize("estimator", [central_difference, local_linear, savgol])
+@pytest.mark.parametrize("W", [3, 5, 7])
+def test_sine_derivative_matches_cos(estimator, W):
+    t = np.linspace(0, 2 * np.pi, 1001)
+    series = np.sin(t)
+    dt = t[1] - t[0]
+    result = estimator(series, dt, W)
+    expected = np.cos(t)
+    assert result.shape == expected.shape
+    assert np.allclose(result, expected, atol=1e-3)

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from core import pressure_uncertainty, bound_pressure
+
+
+def test_pressure_uncertainty_and_bounds():
+    dp_dt = np.array([1.0, -2.0, 0.5])
+    e_align = np.array([0.1, 0.2, 0.3])
+    kappa = 0.5
+
+    expected = kappa * np.abs(dp_dt) * e_align
+    delta = pressure_uncertainty(dp_dt, e_align, kappa)
+    np.testing.assert_allclose(delta, expected)
+
+    lower, upper = bound_pressure(dp_dt, e_align, kappa)
+    np.testing.assert_allclose(lower, -expected)
+    np.testing.assert_allclose(upper, expected)
+    assert np.all(lower <= 0)
+    assert np.all(upper >= 0)


### PR DESCRIPTION
## Summary
- add regression tests for derivative estimators against analytic cosine
- verify pressure uncertainty formula and bounds
- configure pytest via pyproject.toml

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae4e25b6808322bee1e39233507c5d