### PR TITLE
Add core calibration and stream alignment utilities

### DIFF
--- a/src/echopress/__init__.py
+++ b/src/echopress/__init__.py
@@ -1,3 +1,5 @@
 """Top-level package for echopress."""
 
-__all__ = ["ingest"]
+from . import ingest, core
+
+__all__ = ["ingest", "core"]

--- a/src/echopress/core/__init__.py
+++ b/src/echopress/core/__init__.py
@@ -1,0 +1,13 @@
+"""Core processing utilities for :mod:`echopress`."""
+
+from .calibration import Calibrator, calibrate
+from .mapping import AlignmentResult, align_midpoints
+from .config import CoreConfig
+
+__all__ = [
+    "Calibrator",
+    "calibrate",
+    "AlignmentResult",
+    "align_midpoints",
+    "CoreConfig",
+]

--- a/src/echopress/core/calibration.py
+++ b/src/echopress/core/calibration.py
@@ -1,0 +1,71 @@
+"""Voltage-to-pressure calibration utilities.
+
+The module exposes :class:`Calibrator` for encapsulating calibration
+coefficients and a convenience :func:`calibrate` function.  Each channel ``k``
+uses coefficients :math:`\alpha_k` and :math:`\beta_k` such that::
+
+    p_k = \alpha_k v_k + \beta_k
+
+where ``v_k`` is the measured voltage and ``p_k`` is the estimated pressure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+import numpy as np
+
+
+@dataclass
+class Calibrator:
+    """Simple affine calibrator using ``alpha`` and ``beta`` coefficients.
+
+    Parameters
+    ----------
+    alpha, beta:
+        Sequences of per-channel coefficients.  They must have the same
+        length.  ``alpha`` corresponds to the multiplicative term and
+        ``beta`` to the additive term.
+    """
+
+    alpha: np.ndarray
+    beta: np.ndarray
+
+    def __post_init__(self) -> None:
+        self.alpha = np.asarray(self.alpha, dtype=float)
+        self.beta = np.asarray(self.beta, dtype=float)
+        if self.alpha.shape != self.beta.shape:
+            raise ValueError("alpha and beta must have the same shape")
+
+    # ------------------------------------------------------------------
+    def __call__(self, voltages: np.ndarray, channel: int | None = None) -> np.ndarray:
+        """Map ``voltages`` to pressures.
+
+        Parameters
+        ----------
+        voltages:
+            Array of voltage readings.  The last dimension is interpreted as
+            channel index.
+        channel:
+            Optional channel selection.  When provided only that channel is
+            processed and a one-dimensional array is returned.
+        """
+        v = np.asarray(voltages, dtype=float)
+        if channel is not None:
+            return self.alpha[channel] * v[..., channel] + self.beta[channel]
+        return self.alpha * v + self.beta
+
+
+# ----------------------------------------------------------------------
+def calibrate(
+    voltages: np.ndarray,
+    alpha: Sequence[float],
+    beta: Sequence[float],
+    *,
+    channel: int | None = None,
+) -> np.ndarray:
+    """Calibrate ``voltages`` using per-channel ``alpha`` and ``beta``.
+
+    This is a thin wrapper around :class:`Calibrator` for convenience.
+    """
+    return Calibrator(np.asarray(alpha), np.asarray(beta))(voltages, channel=channel)

--- a/src/echopress/core/config.py
+++ b/src/echopress/core/config.py
@@ -1,0 +1,35 @@
+"""Configuration structures for the :mod:`echopress.core` package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+
+@dataclass
+class CoreConfig:
+    """Configuration options governing calibration and mapping.
+
+    Attributes
+    ----------
+    alpha, beta:
+        Calibration coefficients.
+    scalar_channel:
+        Index of the O-stream channel considered scalar.
+    O_max:
+        Maximum allowable alignment difference.
+    tie_break:
+        Tie-breaking strategy used during alignment.
+    W:
+        Window size when computing O-stream midpoints from boundaries.
+    kappa:
+        Multiplier applied to the alignment error metric.
+    """
+
+    alpha: Sequence[float] = field(default_factory=lambda: (1.0,))
+    beta: Sequence[float] = field(default_factory=lambda: (0.0,))
+    scalar_channel: int = 0
+    O_max: float | None = None
+    tie_break: str = "nearest"
+    W: int = 1
+    kappa: float = 1.0

--- a/src/echopress/core/mapping.py
+++ b/src/echopress/core/mapping.py
@@ -1,0 +1,91 @@
+"""Temporal mapping utilities between O- and P-streams."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+import numpy as np
+
+
+@dataclass
+class AlignmentResult:
+    """Result of aligning an O-stream to a P-stream."""
+
+    indices: np.ndarray
+    e_align: float
+    midpoints: np.ndarray
+    deltas: np.ndarray
+
+
+# ----------------------------------------------------------------------
+def _midpoints(timestamps: np.ndarray, window: int) -> np.ndarray:
+    ts = np.asarray(timestamps, dtype=float)
+    if ts.ndim == 2 and ts.shape[1] == 2:
+        return ts.mean(axis=1)
+    if ts.ndim == 1:
+        if len(ts) < window + 1:
+            raise ValueError("not enough timestamps for window")
+        return (ts[:-window] + ts[window:]) / 2.0
+    raise ValueError("Unsupported timestamps shape")
+
+
+# ----------------------------------------------------------------------
+def align_midpoints(
+    p_times: Sequence[float],
+    o_times: Sequence[float] | np.ndarray,
+    *,
+    O_max: float | None = None,
+    tie_break: str = "nearest",
+    W: int = 1,
+    kappa: float = 1.0,
+) -> AlignmentResult:
+    """Align O-stream midpoints to the nearest P-stream timestamps.
+
+    Parameters
+    ----------
+    p_times:
+        Sequence of P-stream timestamps.
+    o_times:
+        O-stream timestamps; either ``(N, 2)`` start/end pairs or a one-
+        dimensional array of boundaries.  Midpoints are computed using a
+        window of size ``W`` when ``o_times`` is one-dimensional.
+    O_max:
+        Optional maximum allowable absolute alignment difference.  If any
+        matched pair exceeds this threshold a :class:`ValueError` is raised.
+    tie_break:
+        Strategy used when an O midpoint is equidistant to two P timestamps.
+        ``"earlier"`` chooses the preceding timestamp, ``"later"`` chooses
+        the following timestamp and ``"nearest"`` selects the earlier one by
+        default.
+    W:
+        Window size used when computing midpoints from one-dimensional
+        ``o_times`` arrays.
+    kappa:
+        Multiplier applied to the alignment error metric ``E_align``.
+    """
+
+    p = np.asarray(p_times, dtype=float)
+    mid = _midpoints(np.asarray(o_times, dtype=float), W)
+
+    idx = np.searchsorted(p, mid)
+    prev_idx = np.clip(idx - 1, 0, len(p) - 1)
+    next_idx = np.clip(idx, 0, len(p) - 1)
+
+    prev_delta = np.abs(mid - p[prev_idx])
+    next_delta = np.abs(mid - p[next_idx])
+
+    if tie_break == "earlier":
+        choose_prev = prev_delta <= next_delta
+    elif tie_break == "later":
+        choose_prev = prev_delta < next_delta
+    else:  # default: nearest
+        choose_prev = prev_delta <= next_delta
+
+    mapping = np.where(choose_prev, prev_idx, next_idx)
+    deltas = np.abs(mid - p[mapping])
+
+    if O_max is not None and np.any(deltas > O_max):
+        raise ValueError("alignment exceeds O_max")
+
+    e_align = kappa * float(np.sum(deltas))
+    return AlignmentResult(indices=mapping, e_align=e_align, midpoints=mid, deltas=deltas)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from echopress.core.calibration import calibrate, Calibrator
+
+
+def test_calibrate_vectorised():
+    volts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    alpha = [2.0, 0.5]
+    beta = [0.0, 1.0]
+    pressures = calibrate(volts, alpha, beta)
+    expected = np.array([[2.0, 2.0], [6.0, 3.0]])
+    assert np.allclose(pressures, expected)
+
+
+def test_calibrate_single_channel():
+    volts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    alpha = [2.0, 0.5]
+    beta = [0.0, 1.0]
+    calib = Calibrator(alpha, beta)
+    pressures = calib(volts, channel=1)
+    expected = np.array([2.0, 3.0])
+    assert np.allclose(pressures, expected)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from echopress.core.mapping import align_midpoints
+
+
+def test_align_midpoints_basic():
+    p = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    o = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    result = align_midpoints(p, o)
+    # midpoints are 0.5,1.5,2.5,3.5 -> nearest indices 0..3
+    assert result.indices.tolist() == [0, 1, 2, 3]
+    assert pytest.approx(result.e_align) == 2.0
+
+
+def test_align_midpoints_tie_break():
+    p = np.array([0.0, 2.0, 4.0])
+    o = np.array([0.0, 2.0, 4.0])
+    # midpoints -> 1,3
+    r_earlier = align_midpoints(p, o, tie_break="earlier")
+    r_later = align_midpoints(p, o, tie_break="later")
+    assert r_earlier.indices.tolist() == [0, 1]
+    assert r_later.indices.tolist() == [1, 2]
+
+
+def test_align_midpoints_o_max():
+    p = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    o = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    with pytest.raises(ValueError):
+        align_midpoints(p, o, O_max=0.4)


### PR DESCRIPTION
## Summary
- add calibration helpers converting voltages to pressure using per-channel alpha/beta coefficients
- implement mapping of O-stream midpoints to nearest P-stream timestamps with configurable alignment behaviour
- expose config dataclass for calibration and mapping parameters and update package exports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4a6d94b8832281d794dc5cf95039