### PR TITLE
Add calibration utilities and tests

### DIFF
--- a/src/echopress/__init__.py
+++ b/src/echopress/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for echopress."""
 
-__all__ = ["ingest"]
+__all__ = ["ingest", "core"]

--- a/src/echopress/core/__init__.py
+++ b/src/echopress/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core algorithms and data structures for echopress."""
+
+from .calibration import CalibrationCoefficients, apply_calibration
+
+__all__ = ["CalibrationCoefficients", "apply_calibration"]

--- a/src/echopress/core/calibration.py
+++ b/src/echopress/core/calibration.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Calibration utilities for converting measured voltages.
+
+This module defines a small helper dataclass for storing per-channel
+calibration coefficients as well as a convenience function to apply the
+calibration to raw voltage measurements.
+
+The calibration relationship for channel :math:`k` is
+
+.. math::
+
+   y_k = \alpha_k x + \beta_k
+
+where ``x`` is the measured voltage and ``y_k`` is the calibrated value in the
+application specific units.
+"""
+
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class CalibrationCoefficients:
+    """Affine calibration coefficients for each acquisition channel.
+
+    Parameters
+    ----------
+    alpha:
+        Array of scale factors :math:`\alpha_k` for each channel. Dimensionless.
+    beta:
+        Array of offsets :math:`\beta_k` for each channel. Same units as the
+        calibrated output.
+
+    Notes
+    -----
+    The ``alpha`` and ``beta`` arrays must have identical shapes. Typically they
+    are one-dimensional with length equal to the number of channels.
+    """
+
+    alpha: np.ndarray
+    beta: np.ndarray
+
+    def __post_init__(self) -> None:
+        self.alpha = np.asarray(self.alpha, dtype=float)
+        self.beta = np.asarray(self.beta, dtype=float)
+        if self.alpha.shape != self.beta.shape:
+            raise ValueError("alpha and beta must have identical shapes")
+
+
+def apply_calibration(voltage: np.ndarray, coeffs: CalibrationCoefficients, channel: int) -> np.ndarray:
+    """Apply affine calibration to a voltage trace for a specific channel.
+
+    Parameters
+    ----------
+    voltage:
+        Array of measured voltages in volts. ``voltage`` may have any shape and
+        will be broadcast against the scalar coefficients. The calibration is
+        applied element-wise.
+    coeffs:
+        :class:`CalibrationCoefficients` containing per-channel ``alpha`` and
+        ``beta`` terms. ``coeffs.alpha[channel]`` and ``coeffs.beta[channel]``
+        are used for the transformation.
+    channel:
+        Index of the channel whose coefficients should be applied. Must be
+        compatible with ``coeffs``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Calibrated values with the same shape as ``voltage``.
+
+    Raises
+    ------
+    IndexError
+        If ``channel`` is outside the valid range of the coefficient arrays.
+    """
+
+    alpha = coeffs.alpha[channel]
+    beta = coeffs.beta[channel]
+    return alpha * np.asarray(voltage) + beta

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from echopress.core import CalibrationCoefficients, apply_calibration
+
+
+def test_apply_calibration_multiple_channels():
+    voltage = np.array([0.0, 1.0, 2.0])
+    coeffs = CalibrationCoefficients(alpha=np.array([1.0, 2.0, -1.0]),
+                                     beta=np.array([0.0, -1.0, 0.5]))
+
+    expected = [1.0 * voltage + 0.0,
+                2.0 * voltage - 1.0,
+                -1.0 * voltage + 0.5]
+
+    for ch, exp in enumerate(expected):
+        np.testing.assert_allclose(apply_calibration(voltage, coeffs, ch), exp)
+
+
+def test_apply_calibration_broadcasting():
+    voltage = np.ones((2, 3))
+    coeffs = CalibrationCoefficients(alpha=np.array([2.0]),
+                                     beta=np.array([1.0]))
+    expected = 2.0 * voltage + 1.0
+    result = apply_calibration(voltage, coeffs, 0)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_mismatched_coefficient_lengths():
+    with pytest.raises(ValueError):
+        CalibrationCoefficients(alpha=np.array([1.0, 2.0]),
+                                beta=np.array([0.0]))


### PR DESCRIPTION
## Summary
- introduce `CalibrationCoefficients` dataclass and `apply_calibration` function for channel-based voltage calibration
- expose calibration helpers via new `echopress.core` subpackage
- add comprehensive tests for multi-channel calibration, broadcasting, and invalid coefficients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae69bffa0c832290c765ef75255c03