### PR TITLE
Add calibration, mapping, and configuration utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "echpressure2"
 version = "0.0.0"
+dependencies = ["numpy", "scipy", "pyyaml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/echopress/__init__.py
+++ b/src/echopress/__init__.py
@@ -1,3 +1,5 @@
 """Top-level package for echopress."""
 
-__all__ = ["ingest"]
+from . import ingest, core
+
+__all__ = ["ingest", "core"]

--- a/src/echopress/core/__init__.py
+++ b/src/echopress/core/__init__.py
@@ -1,0 +1,26 @@
+"""Core utilities for the ``echopress`` package."""
+
+from .calibration import calibrate
+from .mapping import AlignmentResult, align_midpoints
+from .config import (
+    CalibrationConfig,
+    PressureConfig,
+    MappingConfig,
+    DerivativeConfig,
+    UncertaintyConfig,
+    DatasetConfig,
+    load_config,
+)
+
+__all__ = [
+    "calibrate",
+    "AlignmentResult",
+    "align_midpoints",
+    "CalibrationConfig",
+    "PressureConfig",
+    "MappingConfig",
+    "DerivativeConfig",
+    "UncertaintyConfig",
+    "DatasetConfig",
+    "load_config",
+]

--- a/src/echopress/core/calibration.py
+++ b/src/echopress/core/calibration.py
@@ -1,0 +1,56 @@
+"""Voltage-to-pressure calibration utilities.
+
+This module implements a simple affine calibration model mapping
+voltages ``v_k`` to pressures ``p_k`` using per-channel coefficients
+``alpha_k`` and ``beta_k``::
+
+    p_k = alpha_k * v_k + beta_k
+
+The :func:`calibrate` function handles either single samples or arrays of
+samples.  An optional ``channel`` argument can be supplied to return a
+specific calibrated channel.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+def calibrate(
+    voltages: Sequence[float] | np.ndarray,
+    alpha: Sequence[float],
+    beta: Sequence[float],
+    channel: int | None = None,
+) -> np.ndarray | float:
+    """Convert voltages to pressure values.
+
+    Parameters
+    ----------
+    voltages:
+        Voltage measurements.  The last dimension corresponds to channels.
+    alpha:
+        Per-channel slope coefficients.
+    beta:
+        Per-channel intercept coefficients.
+    channel:
+        Optional channel index to select a single calibrated channel.
+
+    Returns
+    -------
+    numpy.ndarray or float
+        Calibrated pressure values.  If ``channel`` is provided, a scalar
+        pressure for that channel is returned.
+    """
+
+    v = np.asarray(voltages, dtype=float)
+    a = np.asarray(alpha, dtype=float)
+    b = np.asarray(beta, dtype=float)
+    pressures = a * v + b
+    if channel is not None:
+        return pressures[..., channel]
+    return pressures
+
+
+__all__ = ["calibrate"]

--- a/src/echopress/core/config.py
+++ b/src/echopress/core/config.py
@@ -1,0 +1,110 @@
+"""Configuration helpers for the echopress core modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+try:  # pragma: no cover - optional dependency guard
+    import yaml
+except ImportError as exc:  # pragma: no cover - runtime error
+    raise RuntimeError("PyYAML is required to load configuration") from exc
+
+
+@dataclass
+class CalibrationConfig:
+    """Affine calibration coefficients."""
+
+    alpha: Sequence[float]
+    beta: Sequence[float]
+
+
+@dataclass
+class PressureConfig:
+    """Pressure channel selection."""
+
+    scalar_channel: int
+
+
+@dataclass
+class MappingConfig:
+    """Parameters controlling O-stream to P-stream mapping."""
+
+    O_max: float
+    tie_breaker: str = "earliest"
+
+
+@dataclass
+class DerivativeConfig:
+    """Derivative estimation parameters."""
+
+    W: int
+
+
+@dataclass
+class UncertaintyConfig:
+    """Uncertainty model parameters."""
+
+    kappa: float
+
+
+@dataclass
+class DatasetConfig:
+    """Aggregate configuration object."""
+
+    calibration: CalibrationConfig
+    pressure: PressureConfig
+    mapping: MappingConfig
+    derivative: DerivativeConfig
+    uncertainty: UncertaintyConfig
+
+
+def load_config(path: str | Path) -> DatasetConfig:
+    """Load a :class:`DatasetConfig` from a YAML file."""
+
+    with open(path, "r", encoding="utf8") as fh:
+        data = yaml.safe_load(fh)
+
+    calib = data.get("calibration", {})
+    press = data.get("pressure", {})
+    mapping = data.get("mapping", {})
+    deriv = data.get("derivative", {})
+    uncert = data.get("uncertainty", {})
+
+    calib_cfg = CalibrationConfig(
+        alpha=list(calib.get("alpha", [])),
+        beta=list(calib.get("beta", [])),
+    )
+    pressure_cfg = PressureConfig(
+        scalar_channel=int(press.get("scalar_channel", 0)),
+    )
+    mapping_cfg = MappingConfig(
+        O_max=float(mapping.get("O_max", float("inf"))),
+        tie_breaker=str(mapping.get("tie_breaker", "earliest")),
+    )
+    derivative_cfg = DerivativeConfig(
+        W=int(deriv.get("W", 1)),
+    )
+    uncertainty_cfg = UncertaintyConfig(
+        kappa=float(uncert.get("kappa", 1.0)),
+    )
+
+    return DatasetConfig(
+        calibration=calib_cfg,
+        pressure=pressure_cfg,
+        mapping=mapping_cfg,
+        derivative=derivative_cfg,
+        uncertainty=uncertainty_cfg,
+    )
+
+
+__all__ = [
+    "CalibrationConfig",
+    "PressureConfig",
+    "MappingConfig",
+    "DerivativeConfig",
+    "UncertaintyConfig",
+    "DatasetConfig",
+    "load_config",
+]

--- a/src/echopress/core/mapping.py
+++ b/src/echopress/core/mapping.py
@@ -1,0 +1,97 @@
+"""Mapping utilities for aligning O-streams to P-streams.
+
+Each O-stream file is assigned a scalar pressure label by aligning its
+midpoint timestamp to the nearest P-stream timestamp.  The alignment
+error ``E_align`` is reported and a maximum permissible misalignment
+``O_max`` can be enforced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Sequence
+
+import numpy as np
+
+
+def _to_seconds(t: float | datetime) -> float:
+    """Convert ``t`` to seconds since the Unix epoch."""
+    if isinstance(t, datetime):
+        return t.timestamp()
+    return float(t)
+
+
+@dataclass
+class AlignmentResult:
+    """Result of aligning an O-stream to the P-stream."""
+
+    p_time: float | datetime
+    pressure: float
+    e_align: float
+
+
+def align_midpoints(
+    ostream_times: Sequence[float | datetime],
+    p_times: Sequence[float | datetime],
+    p_pressures: Sequence[float],
+    O_max: float,
+    tie_breaker: str = "earliest",
+) -> AlignmentResult:
+    """Align O-stream midpoint to nearest P-stream timestamp.
+
+    Parameters
+    ----------
+    ostream_times:
+        Timestamps of samples in the O-stream file.
+    p_times:
+        Sequence of P-stream timestamps.
+    p_pressures:
+        Pressure values corresponding to ``p_times``.
+    O_max:
+        Maximum acceptable alignment error in seconds.
+    tie_breaker:
+        Policy for resolving equidistant matches (``"earliest"`` or
+        ``"latest"``).
+
+    Returns
+    -------
+    AlignmentResult
+        Dataclass containing the selected P-stream timestamp, its
+        pressure and the alignment error ``E_align``.
+
+    Raises
+    ------
+    ValueError
+        If ``ostream_times`` is empty or ``E_align`` exceeds ``O_max``.
+    """
+
+    if len(ostream_times) == 0:
+        raise ValueError("ostream_times must not be empty")
+
+    t0 = _to_seconds(ostream_times[0])
+    t1 = _to_seconds(ostream_times[-1])
+    t_mid = (t0 + t1) / 2.0
+
+    p_secs = np.array([_to_seconds(t) for t in p_times], dtype=float)
+    diffs = np.abs(p_secs - t_mid)
+    min_diff = diffs.min()
+    candidate_idxs = np.flatnonzero(diffs == min_diff)
+    if len(candidate_idxs) > 1:
+        if tie_breaker == "latest":
+            idx = candidate_idxs[-1]
+        else:
+            idx = candidate_idxs[0]
+    else:
+        idx = candidate_idxs[0]
+
+    e_align = float(min_diff)
+    if e_align > O_max:
+        raise ValueError("Alignment error exceeds O_max")
+
+    return AlignmentResult(
+        p_time=p_times[idx], pressure=float(p_pressures[idx]), e_align=e_align
+    )
+
+
+__all__ = ["AlignmentResult", "align_midpoints"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from echopress.core import calibrate
+
+
+def test_calibrate_vector_and_scalar():
+    alpha = [1.0, 2.0, 3.0]
+    beta = [0.0, -1.0, 1.0]
+    v = np.array([1.0, 2.0, 3.0])
+    pressures = calibrate(v, alpha, beta)
+    expected = np.array([1.0, 3.0, 10.0])
+    np.testing.assert_allclose(pressures, expected)
+    scalar = calibrate(v, alpha, beta, channel=2)
+    assert scalar == expected[2]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+import pytest
+
+from echopress.core import load_config
+
+
+def test_load_config(tmp_path):
+    text = (
+        "calibration:\n"
+        "  alpha: [1, 2, 3]\n"
+        "  beta: [0, 0, 0]\n"
+        "pressure:\n"
+        "  scalar_channel: 2\n"
+        "mapping:\n"
+        "  O_max: 0.5\n"
+        "  tie_breaker: latest\n"
+        "derivative:\n"
+        "  W: 5\n"
+        "uncertainty:\n"
+        "  kappa: 0.5\n"
+    )
+    path = tmp_path / "cfg.yml"
+    path.write_text(text)
+    cfg = load_config(path)
+    assert cfg.calibration.alpha == [1, 2, 3]
+    assert cfg.calibration.beta == [0, 0, 0]
+    assert cfg.pressure.scalar_channel == 2
+    assert cfg.mapping.O_max == pytest.approx(0.5)
+    assert cfg.mapping.tie_breaker == "latest"
+    assert cfg.derivative.W == 5
+    assert cfg.uncertainty.kappa == pytest.approx(0.5)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from echopress.core import align_midpoints
+
+
+def test_align_midpoints_tie_breaking_and_Omax():
+    p_times = np.array([0.0, 10.0])
+    p_pressures = np.array([100.0, 200.0])
+    o_times = np.linspace(0.0, 10.0, 11)
+
+    result = align_midpoints(o_times, p_times, p_pressures, O_max=6, tie_breaker="earliest")
+    assert result.pressure == pytest.approx(100.0)
+    assert result.e_align == pytest.approx(5.0)
+
+    result2 = align_midpoints(o_times, p_times, p_pressures, O_max=6, tie_breaker="latest")
+    assert result2.pressure == pytest.approx(200.0)
+
+    with pytest.raises(ValueError):
+        align_midpoints(o_times, p_times, p_pressures, O_max=4)


### PR DESCRIPTION
## Summary
- implement voltage-to-pressure calibration using per-channel coefficients
- map O-stream midpoints to nearest P-stream timestamps with alignment error checks
- provide YAML-driven configuration for calibration, mapping, derivative window, and uncertainty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4fa284e483228049042e4a41b554