### PR TITLE
Implement O/P stream alignment utility and tests

### DIFF
--- a/src/echopress/core/__init__.py
+++ b/src/echopress/core/__init__.py
@@ -1,5 +1,11 @@
 """Core algorithms and data structures for echopress."""
 
 from .calibration import CalibrationCoefficients, apply_calibration
+from .mapping import AlignmentResult, align_streams
 
-__all__ = ["CalibrationCoefficients", "apply_calibration"]
+__all__ = [
+    "CalibrationCoefficients",
+    "apply_calibration",
+    "AlignmentResult",
+    "align_streams",
+]

--- a/src/echopress/core/mapping.py
+++ b/src/echopress/core/mapping.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+"""Utilities for aligning O-stream and P-stream timelines."""
+
+from dataclasses import dataclass, field
+from typing import Sequence, Dict, Any
+
+import numpy as np
+
+from ..ingest import OStream, PStreamRecord
+
+
+@dataclass
+class AlignmentResult:
+    """Result of aligning O- and P-streams.
+
+    Attributes
+    ----------
+    mapping:
+        Array mapping each O-stream midpoint to the index of the nearest
+        P-stream record.
+    E_align:
+        Array of absolute time differences between each midpoint and the
+        selected P-stream timestamp.
+    diagnostics:
+        Free-form dictionary containing any auxiliary information generated
+        during the alignment process.
+    """
+
+    mapping: np.ndarray
+    E_align: np.ndarray
+    diagnostics: Dict[str, Any] = field(default_factory=dict)
+
+
+def align_streams(
+    ostream: OStream,
+    pstream: Sequence[PStreamRecord],
+    *,
+    tie_break: str,
+    O_max: float,
+    W: int,
+    kappa: float,
+) -> AlignmentResult:
+    """Align O-stream sample midpoints to the nearest P-stream timestamps.
+
+    Parameters
+    ----------
+    ostream:
+        :class:`OStream` containing sample timestamps ``T^O`` in seconds.
+    pstream:
+        Sequence of :class:`PStreamRecord` objects ordered by timestamp.
+    tie_break:
+        Strategy used when a midpoint is equidistant from two P-stream
+        timestamps.  ``"earlier"`` selects the earlier record whereas
+        ``"later"`` selects the later one.
+    O_max:
+        Maximum permissible alignment error in seconds.  If any midpoint is
+        farther than ``O_max`` from the nearest P-stream record a
+        :class:`ValueError` is raised.
+    W, kappa:
+        Currently unused but retained for diagnostic purposes.
+
+    Returns
+    -------
+    AlignmentResult
+        Dataclass containing the index mapping, the per-midpoint alignment
+        error array and any diagnostics.
+    """
+    if tie_break not in {"earlier", "later"}:
+        raise ValueError("tie_break must be 'earlier' or 'later'")
+
+    o_times = np.asarray(ostream.timestamps, dtype=float)
+    if o_times.ndim != 1 or o_times.size < 2:
+        raise ValueError("ostream must contain at least two timestamps")
+
+    midpoints = (o_times[:-1] + o_times[1:]) / 2.0
+
+    p_times = np.array([rec.timestamp.timestamp() for rec in pstream], dtype=float)
+    if p_times.size == 0:
+        raise ValueError("pstream is empty")
+
+    mapping = np.empty(midpoints.shape, dtype=int)
+    E_align = np.empty(midpoints.shape, dtype=float)
+
+    for i, mp in enumerate(midpoints):
+        j = np.searchsorted(p_times, mp, side="left")
+        if j == 0:
+            idx = 0
+        elif j == len(p_times):
+            idx = len(p_times) - 1
+        else:
+            prev_diff = abs(mp - p_times[j - 1])
+            next_diff = abs(p_times[j] - mp)
+            if prev_diff < next_diff:
+                idx = j - 1
+            elif prev_diff > next_diff:
+                idx = j
+            else:
+                idx = j - 1 if tie_break == "earlier" else j
+        mapping[i] = idx
+        E_align[i] = abs(mp - p_times[idx])
+        if E_align[i] > O_max:
+            raise ValueError(
+                f"Alignment error {E_align[i]:.3f}s exceeds O_max at index {i}"
+            )
+
+    diagnostics = {"tie_break": tie_break, "O_max": O_max, "W": W, "kappa": kappa, "midpoints": midpoints}
+    return AlignmentResult(mapping=mapping, E_align=E_align, diagnostics=diagnostics)
+

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+from datetime import datetime, timezone
+
+from echopress.ingest import OStream, PStreamRecord
+from echopress.core import align_streams
+
+
+def make_pstream(times):
+    return [PStreamRecord(datetime.fromtimestamp(t, tz=timezone.utc), 0.0) for t in times]
+
+
+def test_basic_alignment():
+    ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
+    pstream = make_pstream([5.0, 15.0])
+    result = align_streams(ostream, pstream, tie_break="earlier", O_max=1.0, W=0, kappa=1.0)
+    np.testing.assert_array_equal(result.mapping, [0, 1])
+    np.testing.assert_allclose(result.E_align, [0.0, 0.0])
+
+
+def test_O_max_enforcement():
+    ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0]), channels=np.zeros((0, 0)), meta={})
+    pstream = make_pstream([100.0])
+    with pytest.raises(ValueError):
+        align_streams(ostream, pstream, tie_break="earlier", O_max=10.0, W=0, kappa=1.0)
+
+
+def test_tie_break_behaviour():
+    ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0]), channels=np.zeros((0, 0)), meta={})
+    pstream = make_pstream([0.0, 10.0])
+    left = align_streams(ostream, pstream, tie_break="earlier", O_max=10.0, W=0, kappa=1.0)
+    assert left.mapping.tolist() == [0]
+    right = align_streams(ostream, pstream, tie_break="later", O_max=10.0, W=0, kappa=1.0)
+    assert right.mapping.tolist() == [1]


### PR DESCRIPTION
## Summary
- Add `AlignmentResult` dataclass and `align_streams` function to map O-stream midpoints to nearest P-stream records with error checks
- Export new alignment utilities through the core package
- Provide tests validating basic alignment, tie-break behaviour and `O_max` enforcement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae6ccfc8a88322b488df580cb42998