### PR TITLE
feat: add flexible signal plotting scripts

### DIFF
--- a/viz/helpers.py
+++ b/viz/helpers.py
@@ -21,6 +21,16 @@ def load_array(path: str | Path) -> np.ndarray:
     return np.loadtxt(p, delimiter=",")
 
 
+def auto_label(path: str | Path) -> str:
+    """Return a concise label derived from ``path``.
+
+    This helper is handy for the CLI entry points where a user often wants to
+    plot a file quickly without manually specifying a label.  The file stem is
+    generally descriptive enough and keeps the scripts terse.
+    """
+    return Path(path).stem
+
+
 def plot_series(ax: plt.Axes, series: Sequence[float], label: str | None = None, **kwargs) -> None:
     """Plot a 1D series on ``ax`` with an optional label."""
     ax.plot(series, label=label, **kwargs)

--- a/viz/plot_adapter.py
+++ b/viz/plot_adapter.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import argparse
+
 import matplotlib.pyplot as plt
 
-from .helpers import load_array, plot_series, save_or_show
+from .helpers import auto_label, load_array, plot_series, save_or_show
 from .styles import apply_style
 
 
@@ -13,6 +14,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Visualise adapter outputs")
     parser.add_argument("--input", required=True, help="Path to the input signal")
     parser.add_argument("--output", required=True, help="Path to the adapter output signal")
+    parser.add_argument("--input-label", help="Label for the input signal")
+    parser.add_argument("--output-label", help="Label for the adapter output signal")
     parser.add_argument("--save", help="Path to save the figure")
     parser.add_argument("--show", action="store_true", help="Display the figure interactively")
     args = parser.parse_args()
@@ -28,10 +31,13 @@ def main() -> None:
     apply_style()
     fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
 
-    plot_series(ax1, inp, label="input")
-    plot_series(ax1, out, label="adapter output")
+    inp_label = args.input_label or auto_label(args.input)
+    out_label = args.output_label or auto_label(args.output)
+
+    plot_series(ax1, inp, label=inp_label)
+    plot_series(ax1, out, label=out_label)
     ax1.set_ylabel("Amplitude")
-    ax1.set_title("Input vs adapter output")
+    ax1.set_title(f"{inp_label} vs {out_label}")
 
     plot_series(ax2, diff, label="difference")
     ax2.set_xlabel("Sample")

--- a/viz/plot_alignment.py
+++ b/viz/plot_alignment.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import argparse
+
 import matplotlib.pyplot as plt
 
-from .helpers import load_array, plot_series, save_or_show
+from .helpers import auto_label, load_array, plot_series, save_or_show
 from .styles import apply_style
 
 
@@ -13,6 +14,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Visualise alignment between two signals")
     parser.add_argument("--reference", required=True, help="Path to the reference signal")
     parser.add_argument("--aligned", required=True, help="Path to the aligned signal")
+    parser.add_argument("--ref-label", help="Label for the reference signal")
+    parser.add_argument("--aligned-label", help="Label for the aligned signal")
     parser.add_argument("--save", help="Path to save the figure")
     parser.add_argument("--show", action="store_true", help="Display the figure interactively")
     args = parser.parse_args()
@@ -28,10 +31,13 @@ def main() -> None:
     apply_style()
     fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
 
-    plot_series(ax1, ref, label="reference")
-    plot_series(ax1, ali, label="aligned")
+    ref_label = args.ref_label or auto_label(args.reference)
+    ali_label = args.aligned_label or auto_label(args.aligned)
+
+    plot_series(ax1, ref, label=ref_label)
+    plot_series(ax1, ali, label=ali_label)
     ax1.set_ylabel("Amplitude")
-    ax1.set_title("Reference vs aligned")
+    ax1.set_title(f"{ref_label} vs {ali_label}")
 
     plot_series(ax2, diff, label="difference")
     ax2.set_xlabel("Sample")

--- a/viz/plot_signals.py
+++ b/viz/plot_signals.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import argparse
+
 import matplotlib.pyplot as plt
 
-from .helpers import load_array, plot_series, save_or_show
+from .helpers import auto_label, load_array, plot_series, save_or_show
 from .styles import apply_style
 
 
@@ -23,7 +24,11 @@ def main() -> None:
     apply_style()
     fig, ax = plt.subplots()
 
-    labels = args.labels or [None] * len(args.signals)
+    if args.labels:
+        labels = args.labels
+    else:
+        labels = [auto_label(p) for p in args.signals]
+
     for path, label in zip(args.signals, labels):
         data = load_array(path)
         plot_series(ax, data, label=label)


### PR DESCRIPTION
## Summary
- add `auto_label` helper for deriving plot labels from file names
- support optional label overrides in `plot_signals`, `plot_alignment`, and `plot_adapter`
- ensure all plotting scripts use shared style settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae74612c948322a66101a5059c0024