### PR TITLE
feat: integrate hydra config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,25 @@
 
 ## Configuration
 
-Runtime behaviour is controlled through `echopress.config.Settings`. The dataclass
-exposes fields for calibration (`alpha`, `beta`, `channel`), stream mapping
-(`O_max`, `tie_break`) and derivative utilities (`W`, `kappa`).
+Runtime configuration is managed with [Hydra](https://hydra.cc).  The default
+configuration in `conf/config.yaml` composes several YAML groups under
+`conf/`, including:
 
-Settings can be provided via environment variables prefixed with `ECHOPRESS_`
-or loaded from a JSON or YAML file using `echopress.config.load_settings`.
+* `dataset` – paths to example O- and P-streams
+* `calibration` – per-channel calibration coefficients
+* `adapter` – parameters for signal adapters
+* `viz` – options for plotting
 
-Functions such as `apply_calibration` and `align_streams` accept a `Settings`
-instance. The derivative estimators also consult these defaults when `W` or
-`kappa` are not supplied explicitly.
+Commands in `echopress.cli` are wrapped by ``hydra.main`` so overrides can be
+passed directly on the command line. For example, to adjust calibration
+parameters at runtime:
+
+```bash
+python -m echopress.cli calibrate data.npy -o out.npy calibration.alpha=2.0
+```
+
+The `Settings` dataclass remains available for functions that expect it. In the
+CLI, values from Hydra's ``calibration`` section are converted into ``Settings``
+instances for compatibility. ``Settings.from_env`` and
+``echopress.config.load_settings`` still allow configuration via environment
+variables or explicit files when Hydra is not desired.


### PR DESCRIPTION
## Summary
- use `hydra.main` to provide configuration for Typer commands
- document Hydra usage and relationship with legacy Settings class

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae7a8018288322a07a164eae5a7625