### PR TITLE
Rename tie_break to tie_breaker and use W/kappa in mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Runtime behaviour is controlled through `echopress.config.Settings`. The dataclass
 exposes fields for calibration (`alpha`, `beta`, `channel`), stream mapping
-(`O_max`, `tie_break`) and derivative utilities (`W`, `kappa`).
+(`O_max`, `tie_breaker`) and derivative utilities (`W`, `kappa`).
 
 Settings can be provided via environment variables prefixed with `ECHOPRESS_`
 or loaded from a JSON or YAML file using `echopress.config.load_settings`.

--- a/conf/mapping/default.yaml
+++ b/conf/mapping/default.yaml
@@ -1,4 +1,4 @@
-tie_break: earlier
+tie_breaker: earliest
 O_max: 0.1
 W: 5
 kappa: 1.0

--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -27,7 +27,7 @@ class Settings:
     beta: float = 0.0
     channel: int = 0
     O_max: float = 0.1
-    tie_break: str = "earlier"
+    tie_breaker: str = "earliest"
     W: int = 5
     kappa: float = 1.0
 
@@ -40,7 +40,7 @@ class Settings:
             "beta": ("ECHOPRESS_BETA", float),
             "channel": ("ECHOPRESS_CHANNEL", int),
             "O_max": ("ECHOPRESS_O_MAX", float),
-            "tie_break": ("ECHOPRESS_TIE_BREAK", str),
+            "tie_breaker": ("ECHOPRESS_TIE_BREAKER", str),
             "W": ("ECHOPRESS_W", int),
             "kappa": ("ECHOPRESS_KAPPA", float),
         }

--- a/src/echopress/core/mapping.py
+++ b/src/echopress/core/mapping.py
@@ -7,6 +7,8 @@ from typing import Sequence, Dict, Any
 
 import numpy as np
 
+from core import pressure_uncertainty
+
 from ..ingest import OStream, PStreamRecord
 from ..config import Settings
 
@@ -38,7 +40,7 @@ def align_streams(
     pstream: Sequence[PStreamRecord],
     *,
     settings: Settings | None = None,
-    tie_break: str | None = None,
+    tie_breaker: str | None = None,
     O_max: float | None = None,
     W: int | None = None,
     kappa: float | None = None,
@@ -54,7 +56,7 @@ def align_streams(
     settings:
         Optional :class:`~echopress.config.Settings` instance providing default
         values for the remaining parameters.
-    tie_break, O_max, W, kappa:
+    tie_breaker, O_max, W, kappa:
         Individual overrides for the respective parameters.  Any value set here
         takes precedence over those supplied in ``settings``.
 
@@ -67,13 +69,13 @@ def align_streams(
     if settings is None:
         settings = Settings()
 
-    tie_break = tie_break or settings.tie_break
+    tie_breaker = tie_breaker or settings.tie_breaker
     O_max = settings.O_max if O_max is None else O_max
     W = settings.W if W is None else W
     kappa = settings.kappa if kappa is None else kappa
 
-    if tie_break not in {"earlier", "later"}:
-        raise ValueError("tie_break must be 'earlier' or 'later'")
+    if tie_breaker not in {"earliest", "latest"}:
+        raise ValueError("tie_breaker must be 'earliest' or 'latest'")
 
     o_times = np.asarray(ostream.timestamps, dtype=float)
     if o_times.ndim != 1 or o_times.size < 2:
@@ -84,6 +86,19 @@ def align_streams(
     p_times = np.array([rec.timestamp.timestamp() for rec in pstream], dtype=float)
     if p_times.size == 0:
         raise ValueError("pstream is empty")
+    p_values = np.array([rec.pressure for rec in pstream], dtype=float)
+
+    # Derivative estimation using a windowed gradient smoothed over W samples
+    if p_values.size >= 2:
+        dp_dt_raw = np.gradient(p_values, p_times)
+    else:
+        dp_dt_raw = np.zeros_like(p_values)
+    W_eff = max(1, min(W, dp_dt_raw.size))
+    if W_eff > 1:
+        kernel = np.ones(W_eff) / W_eff
+        dp_dt = np.convolve(dp_dt_raw, kernel, mode="same")
+    else:
+        dp_dt = dp_dt_raw
 
     mapping = np.empty(midpoints.shape, dtype=int)
     E_align = np.empty(midpoints.shape, dtype=float)
@@ -102,7 +117,7 @@ def align_streams(
             elif prev_diff > next_diff:
                 idx = j
             else:
-                idx = j - 1 if tie_break == "earlier" else j
+                idx = j - 1 if tie_breaker == "earliest" else j
         mapping[i] = idx
         E_align[i] = abs(mp - p_times[idx])
         if E_align[i] > O_max:
@@ -110,6 +125,15 @@ def align_streams(
                 f"Alignment error {E_align[i]:.3f}s exceeds O_max at index {i}"
             )
 
-    diagnostics = {"tie_break": tie_break, "O_max": O_max, "W": W, "kappa": kappa, "midpoints": midpoints}
+    delta_p = pressure_uncertainty(dp_dt[mapping], E_align, kappa)
+    diagnostics = {
+        "tie_breaker": tie_breaker,
+        "O_max": O_max,
+        "W": W,
+        "kappa": kappa,
+        "midpoints": midpoints,
+        "dp_dt": dp_dt,
+        "pressure_uncertainty": delta_p,
+    }
     return AlignmentResult(mapping=mapping, E_align=E_align, diagnostics=diagnostics)
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+import numpy as np
+import pytest
 from datetime import datetime, timezone
 
 from echopress.config import Settings
@@ -14,7 +16,7 @@ def make_pstream(times):
 def test_basic_alignment():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
     pstream = make_pstream([5.0, 15.0])
-    result = align_streams(ostream, pstream, tie_break="earlier", O_max=1.0, W=0, kappa=1.0)
+    result = align_streams(ostream, pstream, tie_breaker="earliest", O_max=1.0, W=0, kappa=1.0)
     np.testing.assert_array_equal(result.mapping, [0, 1])
     np.testing.assert_allclose(result.E_align, [0.0, 0.0])
 
@@ -23,21 +25,21 @@ def test_O_max_enforcement():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0]), channels=np.zeros((0, 0)), meta={})
     pstream = make_pstream([100.0])
     with pytest.raises(ValueError):
-        align_streams(ostream, pstream, tie_break="earlier", O_max=10.0, W=0, kappa=1.0)
+        align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=0, kappa=1.0)
 
 
 def test_tie_break_behaviour():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0]), channels=np.zeros((0, 0)), meta={})
     pstream = make_pstream([0.0, 10.0])
-    left = align_streams(ostream, pstream, tie_break="earlier", O_max=10.0, W=0, kappa=1.0)
+    left = align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=0, kappa=1.0)
     assert left.mapping.tolist() == [0]
-    right = align_streams(ostream, pstream, tie_break="later", O_max=10.0, W=0, kappa=1.0)
+    right = align_streams(ostream, pstream, tie_breaker="latest", O_max=10.0, W=0, kappa=1.0)
     assert right.mapping.tolist() == [1]
 
 
 def test_alignment_with_settings():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
     pstream = make_pstream([5.0, 15.0])
-    settings = Settings(tie_break="earlier", O_max=1.0, W=0, kappa=1.0)
+    settings = Settings(tie_breaker="earliest", O_max=1.0, W=0, kappa=1.0)
     result = align_streams(ostream, pstream, settings=settings)
     np.testing.assert_array_equal(result.mapping, [0, 1])


### PR DESCRIPTION
## Summary
- Rename tie_break to tie_breaker across configuration, defaults, tests and mapping
- Accept "earliest"/"latest" for tie-breaking and compute derivatives with W
- Use kappa with pressure_uncertainty and expose derivative/uncertainty diagnostics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae7ae39dc083228b17dc9b380b829e