### PR TITLE
Rename tie_break to tie_breaker and compute uncertainty

### DIFF
--- a/conf/mapping/default.yaml
+++ b/conf/mapping/default.yaml
@@ -1,4 +1,4 @@
-tie_break: earlier
+tie_breaker: earliest
 O_max: 0.1
 W: 5
 kappa: 1.0

--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -27,7 +27,7 @@ class Settings:
     beta: float = 0.0
     channel: int = 0
     O_max: float = 0.1
-    tie_break: str = "earlier"
+    tie_breaker: str = "earliest"
     W: int = 5
     kappa: float = 1.0
 
@@ -40,7 +40,7 @@ class Settings:
             "beta": ("ECHOPRESS_BETA", float),
             "channel": ("ECHOPRESS_CHANNEL", int),
             "O_max": ("ECHOPRESS_O_MAX", float),
-            "tie_break": ("ECHOPRESS_TIE_BREAK", str),
+            "tie_breaker": ("ECHOPRESS_TIE_BREAKER", str),
             "W": ("ECHOPRESS_W", int),
             "kappa": ("ECHOPRESS_KAPPA", float),
         }

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -8,36 +8,45 @@ from echopress.core import align_streams
 
 
 def make_pstream(times):
-    return [PStreamRecord(datetime.fromtimestamp(t, tz=timezone.utc), 0.0) for t in times]
+    return [PStreamRecord(datetime.fromtimestamp(t, tz=timezone.utc), t) for t in times]
 
 
 def test_basic_alignment():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
-    pstream = make_pstream([5.0, 15.0])
-    result = align_streams(ostream, pstream, tie_break="earlier", O_max=1.0, W=0, kappa=1.0)
+    pstream = make_pstream([5.0, 15.0, 25.0])
+    result = align_streams(ostream, pstream, tie_breaker="earliest", O_max=1.0, W=3, kappa=1.0)
     np.testing.assert_array_equal(result.mapping, [0, 1])
     np.testing.assert_allclose(result.E_align, [0.0, 0.0])
 
 
 def test_O_max_enforcement():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0]), channels=np.zeros((0, 0)), meta={})
-    pstream = make_pstream([100.0])
+    pstream = make_pstream([100.0, 110.0, 120.0])
     with pytest.raises(ValueError):
-        align_streams(ostream, pstream, tie_break="earlier", O_max=10.0, W=0, kappa=1.0)
+        align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=3, kappa=1.0)
 
 
 def test_tie_break_behaviour():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0]), channels=np.zeros((0, 0)), meta={})
-    pstream = make_pstream([0.0, 10.0])
-    left = align_streams(ostream, pstream, tie_break="earlier", O_max=10.0, W=0, kappa=1.0)
+    pstream = make_pstream([0.0, 10.0, 20.0])
+    left = align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=3, kappa=1.0)
     assert left.mapping.tolist() == [0]
-    right = align_streams(ostream, pstream, tie_break="later", O_max=10.0, W=0, kappa=1.0)
+    right = align_streams(ostream, pstream, tie_breaker="latest", O_max=10.0, W=3, kappa=1.0)
     assert right.mapping.tolist() == [1]
 
 
 def test_alignment_with_settings():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
-    pstream = make_pstream([5.0, 15.0])
-    settings = Settings(tie_break="earlier", O_max=1.0, W=0, kappa=1.0)
+    pstream = make_pstream([5.0, 15.0, 25.0])
+    settings = Settings(tie_breaker="earliest", O_max=1.0, W=3, kappa=1.0)
     result = align_streams(ostream, pstream, settings=settings)
     np.testing.assert_array_equal(result.mapping, [0, 1])
+
+
+def test_derivative_and_uncertainty():
+    ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
+    pstream = make_pstream([6.0, 16.0, 26.0])
+    result = align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=3, kappa=0.5)
+    np.testing.assert_allclose(result.diagnostics["dp_dt"], [1.0, 1.0], atol=1e-6)
+    np.testing.assert_allclose(result.diagnostics["delta_p"], [0.5, 0.5], atol=1e-6)
+


### PR DESCRIPTION
## Summary
- rename `tie_break` configuration option to `tie_breaker` with `earliest`/`latest` values
- use window `W` and factor `kappa` to compute pressure derivative and uncertainty during stream alignment
- update default configuration and tests for new behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae7c6f08fc83229244ad294f547d19