### PR TITLE
Change default channel to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ configuration in `conf/config.yaml` composes several YAML groups under
 * `adapter` – parameters for signal adapters
 * `viz` – options for plotting
 
+By default, the library operates on channel `3`. Override this with
+`calibration.channel` or the `ECHOPRESS_CHANNEL` environment variable.
+
 Commands in `echopress.cli` are wrapped by ``hydra.main`` so overrides can be
 passed directly on the command line. For example, to adjust calibration
 parameters at runtime:

--- a/conf/calibration/default.yaml
+++ b/conf/calibration/default.yaml
@@ -1,3 +1,3 @@
 alpha: 1.0
 beta: 0.0
-channel: 0
+channel: 3

--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -25,7 +25,7 @@ class Settings:
 
     alpha: float = 1.0
     beta: float = 0.0
-    channel: int = 0
+    channel: int = 3
     O_max: float = 0.1
     tie_breaker: str = "earliest"
     W: int = 5

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -35,7 +35,8 @@ def test_mismatched_coefficient_lengths():
 
 def test_apply_calibration_with_settings():
     voltage = np.array([0.0, 1.0])
-    settings = Settings(alpha=2.0, beta=1.0, channel=0)
+    settings = Settings(alpha=2.0, beta=1.0)
+    assert settings.channel == 3
     result = apply_calibration(voltage, settings=settings)
     np.testing.assert_allclose(result, 2.0 * voltage + 1.0)
 


### PR DESCRIPTION
## Summary
- default to channel 3 in Settings and config
- document and test new channel default

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae818c588883229ef39fb690711489