### PR TITLE
Parse multi-channel voltages with calibration

### DIFF
--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -8,7 +8,14 @@ from echopress.core import align_streams
 
 
 def make_pstream(times):
-    return [PStreamRecord(datetime.fromtimestamp(t, tz=timezone.utc), t) for t in times]
+    return [
+        PStreamRecord(
+            datetime.fromtimestamp(t, tz=timezone.utc),
+            (0.0, 0.0, t),
+            t,
+        )
+        for t in times
+    ]
 
 
 def test_basic_alignment():


### PR DESCRIPTION
## Summary
- Read three voltage columns in P-streams
- Calibrate voltages and provide scalar pressure from channel 3
- Update mapping tests for new PStreamRecord structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae838922ac83228619c13ebacd268f