### PR TITLE
Add derivative method selection and pressure uncertainty bounds

### DIFF
--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -29,6 +29,7 @@ class Settings:
     O_max: float = 0.1
     tie_breaker: str = "earliest"
     W: int = 5
+    derivative_method: str = "central_difference"
     kappa: float = 1.0
 
     @classmethod
@@ -42,6 +43,7 @@ class Settings:
             "O_max": ("ECHOPRESS_O_MAX", float),
             "tie_breaker": ("ECHOPRESS_TIE_BREAKER", str),
             "W": ("ECHOPRESS_W", int),
+            "derivative_method": ("ECHOPRESS_DERIVATIVE_METHOD", str),
             "kappa": ("ECHOPRESS_KAPPA", float),
         }
         data: Dict[str, Any] = {}

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -53,7 +53,19 @@ def test_alignment_with_settings():
 def test_derivative_and_uncertainty():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
     pstream = make_pstream([6.0, 16.0, 26.0])
-    result = align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=3, kappa=0.5)
+    result = align_streams(
+        ostream,
+        pstream,
+        tie_breaker="earliest",
+        O_max=10.0,
+        W=3,
+        method="local_linear",
+        kappa=0.5,
+    )
     np.testing.assert_allclose(result.diagnostics["dp_dt"], [1.0, 1.0], atol=1e-6)
-    np.testing.assert_allclose(result.diagnostics["delta_p"], [0.5, 0.5], atol=1e-6)
+    np.testing.assert_allclose(result.diagnostics["uncertainty"], [0.5, 0.5], atol=1e-6)
+    np.testing.assert_allclose(result.P_bounds[0], [-0.5, -0.5], atol=1e-6)
+    np.testing.assert_allclose(result.P_bounds[1], [0.5, 0.5], atol=1e-6)
+    assert result.diagnostics["derivative_method"] == "local_linear"
+    assert result.diagnostics["window_size"] == 3
 


### PR DESCRIPTION
## Summary
- compute dp/dt using a selectable derivative estimator and window size
- derive pressure uncertainty bounds |ΔP| ≤ κ·|dp/dt|·E_align and expose them
- expand diagnostics with derivative method, window size, and uncertainty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae868cb0308322bf4e26b0490d429f