### PR TITLE
Add utility helpers and core type definitions

### DIFF
--- a/src/echopress/types.py
+++ b/src/echopress/types.py
@@ -1,0 +1,58 @@
+"""Common type helpers for echopress.
+
+This module defines lightweight containers and ``TypedDict`` instances
+used across the codebase.  The structures are intentionally minimal but
+add clarity and type safety around frequently exchanged data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, TypedDict
+
+
+class Sample(TypedDict):
+    """Representation of a single data sample."""
+
+    t: float
+    value: float
+
+
+@dataclass(frozen=True)
+class TimeInterval:
+    """Simple interval of time expressed in seconds."""
+
+    start: float
+    end: float
+
+    @property
+    def duration(self) -> float:
+        """Return the interval length in seconds."""
+
+        return self.end - self.start
+
+
+@dataclass(frozen=True)
+class Window:
+    """Index based window used for segmenting sequences."""
+
+    start: int
+    end: int
+
+    @property
+    def width(self) -> int:
+        """Return the number of elements covered by the window."""
+
+        return self.end - self.start
+
+
+@dataclass
+class TimeSeries:
+    """Container for paired time and value sequences."""
+
+    times: Sequence[float]
+    values: Sequence[float]
+
+    def __post_init__(self) -> None:  # pragma: no cover - tiny helper
+        if len(self.times) != len(self.values):
+            raise ValueError("times and values must have the same length")

--- a/src/echopress/utils/__init__.py
+++ b/src/echopress/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility subpackage for echopress."""
+
+__all__ = ["timeparse", "signals", "windows", "logging"]

--- a/src/echopress/utils/logging.py
+++ b/src/echopress/utils/logging.py
@@ -1,0 +1,24 @@
+"""Minimal logging helpers for the project."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+DEFAULT_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+
+def get_logger(name: str = "echopress", level: int = logging.INFO, fmt: str = DEFAULT_FORMAT) -> logging.Logger:
+    """Return a configured :class:`logging.Logger` instance.
+
+    A new ``StreamHandler`` is added only once per-logger to avoid
+    duplicate log lines when calling this function multiple times.
+    """
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(fmt))
+        logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger

--- a/src/echopress/utils/signals.py
+++ b/src/echopress/utils/signals.py
@@ -1,0 +1,37 @@
+"""Signal processing helpers."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, Sequence, List
+
+
+def rms(data: Sequence[float]) -> float:
+    """Return the root-mean-square of *data*.
+
+    ``ValueError`` is raised for empty sequences.
+    """
+
+    if not data:
+        raise ValueError("data must not be empty")
+    return math.sqrt(sum(x * x for x in data) / len(data))
+
+
+def moving_average(data: Sequence[float], window: int) -> List[float]:
+    """Compute the simple moving average over *data*.
+
+    The result has ``len(data) - window + 1`` elements.  ``ValueError`` is
+    raised if ``window`` is not positive or greater than ``len(data)``.
+    """
+
+    if window <= 0:
+        raise ValueError("window must be positive")
+    if window > len(data):
+        raise ValueError("window larger than data")
+    out: List[float] = []
+    total = sum(data[:window])
+    out.append(total / window)
+    for i in range(window, len(data)):
+        total += data[i] - data[i - window]
+        out.append(total / window)
+    return out

--- a/src/echopress/utils/timeparse.py
+++ b/src/echopress/utils/timeparse.py
@@ -1,0 +1,38 @@
+"""Utilities for parsing human friendly time expressions."""
+
+from __future__ import annotations
+
+
+def parse_time(text: str) -> float:
+    """Parse ``text`` as a time value in seconds.
+
+    Accepted formats are:
+
+    * ``HH:MM:SS``
+    * ``MM:SS``
+    * ``SS``
+
+    Fractional seconds are supported.  ``ValueError`` is raised on
+    malformed input.
+    """
+
+    parts = text.strip().split(":")
+    if not parts:
+        raise ValueError("empty time string")
+
+    try:
+        parts_f = [float(p) for p in parts]
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError("invalid time value") from exc
+
+    if len(parts_f) == 1:
+        seconds = parts_f[0]
+    elif len(parts_f) == 2:
+        minutes, seconds = parts_f
+        seconds += minutes * 60
+    elif len(parts_f) == 3:
+        hours, minutes, seconds = parts_f
+        seconds += minutes * 60 + hours * 3600
+    else:
+        raise ValueError("too many components in time string")
+    return seconds

--- a/src/echopress/utils/windows.py
+++ b/src/echopress/utils/windows.py
@@ -1,0 +1,31 @@
+"""Helpers for working with sliding windows over sequences."""
+
+from __future__ import annotations
+
+from typing import Iterator, Sequence, TypeVar, List
+
+from ..types import Window
+
+T = TypeVar("T")
+
+
+def iter_windows(data: Sequence[T], size: int, step: int = 1) -> Iterator[Window]:
+    """Yield ``Window`` objects describing slices of *data*.
+
+    ``size`` is the window length and ``step`` controls how far the
+    window advances each iteration.  ``ValueError`` is raised if the
+    arguments are not sensible.
+    """
+
+    if size <= 0 or step <= 0:
+        raise ValueError("size and step must be positive")
+    if size > len(data):
+        raise ValueError("size larger than data")
+    for start in range(0, len(data) - size + 1, step):
+        yield Window(start, start + size)
+
+
+def window_slices(data: Sequence[T], size: int, step: int = 1) -> List[Sequence[T]]:
+    """Return the subsequences for each sliding window."""
+
+    return [data[w.start : w.end] for w in iter_windows(data, size, step)]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+import logging
+import pytest
+import math
+
+from echopress.types import Sample, TimeInterval, TimeSeries, Window
+from echopress.utils.timeparse import parse_time
+from echopress.utils.signals import rms, moving_average
+from echopress.utils.windows import iter_windows, window_slices
+from echopress.utils.logging import get_logger
+
+
+def test_types():
+    s: Sample = {"t": 1.0, "value": 2.0}
+    assert s["t"] == 1.0
+    ti = TimeInterval(0.0, 2.5)
+    assert ti.duration == 2.5
+    w = Window(2, 5)
+    assert w.width == 3
+    with pytest.raises(ValueError):
+        TimeSeries([0, 1], [1])
+
+
+def test_parse_time():
+    assert parse_time("1:02:03.5") == pytest.approx(3723.5)
+    assert parse_time("02:03") == pytest.approx(123)
+    assert parse_time("45") == pytest.approx(45)
+    with pytest.raises(ValueError):
+        parse_time("bad")
+
+
+def test_signals():
+    data = [1.0, 2.0, 3.0, 4.0]
+    expected = math.sqrt((1 ** 2 + 2 ** 2 + 3 ** 2 + 4 ** 2) / 4)
+    assert rms(data) == pytest.approx(expected)
+    assert moving_average(data, 2) == [1.5, 2.5, 3.5]
+    with pytest.raises(ValueError):
+        moving_average(data, 0)
+
+
+def test_windows():
+    data = [1, 2, 3, 4, 5]
+    ws = list(iter_windows(data, 3, 2))
+    assert ws == [Window(0, 3), Window(2, 5)]
+    slices = window_slices(data, 3, 2)
+    assert slices == [[1, 2, 3], [3, 4, 5]]
+
+
+def test_logging():
+    logger = get_logger("test")
+    logger2 = get_logger("test")
+    assert logger is logger2
+    assert len(logger.handlers) == 1
+    logger.debug("debug message")


### PR DESCRIPTION
## Summary
- add common dataclasses and TypedDicts for samples, time intervals and windows
- implement utility modules for time parsing, signal stats, sliding windows and logging setup
- cover new utilities with unit tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae89a315908322920b693631a57bc9