### PR TITLE
refactor adapter config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ configuration in `conf/config.yaml` composes several YAML groups under
 By default, the library operates on channel `3`. Override this with
 `calibration.channel` or the `ECHOPRESS_CHANNEL` environment variable.
 
+The adapter section uses a nested schema. A minimal configuration looks like:
+
+```yaml
+adapter:
+  name: cec
+  output_length: 0  # use full output
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 Commands in `echopress.cli` are wrapped by ``hydra.main`` so overrides can be
 passed directly on the command line. For example, to adjust calibration
 parameters at runtime:

--- a/conf/adapter/cec.yaml
+++ b/conf/adapter/cec.yaml
@@ -1,4 +1,5 @@
 name: cec
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/default.yaml
+++ b/conf/adapter/default.yaml
@@ -1,3 +1,5 @@
 name: cec
-fs: 1.0
-f0: 1.0
+output_length: 0
+period_est:
+  fs: 1.0
+  f0: 1.0

--- a/conf/adapter/dtw_ta.yaml
+++ b/conf/adapter/dtw_ta.yaml
@@ -1,4 +1,5 @@
 name: dtw_ta
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/fts.yaml
+++ b/conf/adapter/fts.yaml
@@ -1,4 +1,5 @@
 name: fts
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/hmv.yaml
+++ b/conf/adapter/hmv.yaml
@@ -1,4 +1,5 @@
 name: hmv
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/hte.yaml
+++ b/conf/adapter/hte.yaml
@@ -1,4 +1,5 @@
 name: hte
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/mfcc.yaml
+++ b/conf/adapter/mfcc.yaml
@@ -1,4 +1,5 @@
 name: mfcc
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/mtp.yaml
+++ b/conf/adapter/mtp.yaml
@@ -1,4 +1,5 @@
 name: mtp
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/pb_csa.yaml
+++ b/conf/adapter/pb_csa.yaml
@@ -1,4 +1,5 @@
 name: pb_csa
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/plstn.yaml
+++ b/conf/adapter/plstn.yaml
@@ -1,4 +1,5 @@
 name: plstn
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/conf/adapter/wcv.yaml
+++ b/conf/adapter/wcv.yaml
@@ -1,4 +1,5 @@
 name: wcv
-fs: 10.0
-f0: 2.0
-
+output_length: 0
+period_est:
+  fs: 10.0
+  f0: 2.0

--- a/src/echopress/adapters/cec/README.md
+++ b/src/echopress/adapters/cec/README.md
@@ -1,3 +1,14 @@
 # cec Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: cec
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/dtw_ta/README.md
+++ b/src/echopress/adapters/dtw_ta/README.md
@@ -1,3 +1,14 @@
 # dtw_ta Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: dtw_ta
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/fts/README.md
+++ b/src/echopress/adapters/fts/README.md
@@ -1,3 +1,14 @@
 # fts Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: fts
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/hmv/README.md
+++ b/src/echopress/adapters/hmv/README.md
@@ -1,3 +1,14 @@
 # hmv Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: hmv
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/hte/README.md
+++ b/src/echopress/adapters/hte/README.md
@@ -1,3 +1,14 @@
 # hte Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: hte
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/mfcc/README.md
+++ b/src/echopress/adapters/mfcc/README.md
@@ -1,3 +1,14 @@
 # mfcc Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: mfcc
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/mtp/README.md
+++ b/src/echopress/adapters/mtp/README.md
@@ -1,3 +1,14 @@
 # mtp Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: mtp
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/pb_csa/README.md
+++ b/src/echopress/adapters/pb_csa/README.md
@@ -1,3 +1,14 @@
 # pb_csa Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: pb_csa
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/plstn/README.md
+++ b/src/echopress/adapters/plstn/README.md
@@ -1,3 +1,14 @@
 # plstn Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: plstn
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/adapters/wcv/README.md
+++ b/src/echopress/adapters/wcv/README.md
@@ -1,3 +1,14 @@
 # wcv Adapter
 
+Example Hydra configuration:
+
+```yaml
+adapter:
+  name: wcv
+  output_length: 0
+  period_est:
+    fs: 10.0
+    f0: 2.0
+```
+
 This adapter is a placeholder implementation.

--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -65,10 +65,15 @@ def adapter(ctx: typer.Context, signal: str, output: str) -> None:
     cfg: DictConfig = ctx.obj
     data = np.load(signal)
     adapter_obj = get_adapter(cfg.adapter.name)
-    cycles = adapter_obj.layer1(data, fs=cfg.adapter.fs, f0=cfg.adapter.f0)
-    outputs = adapter_obj.layer2(cycles, fs=cfg.adapter.fs)
+    fs = cfg.adapter.period_est.fs
+    f0 = cfg.adapter.period_est.f0
+    cycles = adapter_obj.layer1(data, fs=fs, f0=f0)
+    outputs = adapter_obj.layer2(cycles, fs=fs)
     first_key = next(iter(outputs))
-    np.save(output, outputs[first_key])
+    result = outputs[first_key]
+    if cfg.adapter.output_length:
+        result = result[..., : cfg.adapter.output_length]
+    np.save(output, result)
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- redesign adapter config to use hierarchical keys for name, output length and period estimation
- update adapter CLI to read new config schema
- document adapter configuration with per-adapter examples

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8c1cedb883229988dc41187dc2c7