### PR TITLE
Document adapter theory and references

### DIFF
--- a/plan.txt
+++ b/plan.txt
@@ -1,0 +1,591 @@
+Modular Python Repository Architecture for
+Pressure–Oscilloscope Dataset Processing, Alignment,
+Adapters, and Visualization
+
+1
+
+Goals & Requirements (from the Specification)
+• Two unsynchronized streams: P-stream (timestamps + voltages → scalar pressure p(3) )
+and O-stream (per-file time series with NF , sampling step δtF ).
+• File-level midpoint alignment to nearest P-stream timestamp; acceptance threshold Omax ;
+uncertainty bound via local derivative ḃ
+pW .
+• In-memory tables for Signals, OscFiles, File2PressureMap; fits in memory, but offer
+optional lazy/batched loading for large corpora.
+• Framework-agnostic outputs (NumPy-first), ready for PyTorch/TF dataset wrappers at a
+later stage.
+• Hydra-driven configuration via YAML (hierarchical, overrideable).
+• Extremely modular adapters: each in its own folder with adapter.py, adapter.yml,
+README.md (math + references), and tests/.
+• Visualization: quick CLI flags to plot raw/processed/adapter outputs (e.g., random samples at given pressure ranges) or return NumPy arrays.
+• Trackability: every record carries keys sid, file_stamp, idx (and run UUID); deterministic tie-breaking and seeding.
+
+2
+
+High-Level Architecture
+• Ingestion & Indexing: resolve dataset paths, parse file names and per-record stamps,
+build in-memory registries.
+• Calibration & Mapping: compute p(3) from voltages, perform midpoint alignment to
+nearest P-stream time, compute Ealign and |∆P | bounds.
+• Adapters Layer 1: cycle-synchronous and fixed-length, shift-invariant mappings (PBCSA, PLSTN, HMV, CEC, DTW-TA, MTP).
+• Adapters Layer 2 (Transforms): FT spectrum, Hilbert-envelope, wavelet energies,
+MFCC.
+• Visualization: reusable plotting and inspection utilities.
+• Export (on-demand): produce in-memory datasets {(xF , p∗ (F ))} for ML; optional saveas you debug (CSV/NPZ).
+
+1
+
+3
+
+Repository Layout (copy/paste)
+
+repo-root/
+pyproject.toml
+README.md
+LICENSE
+.gitignore
+.pre-commit-config.yaml
+conf/
+config.yaml
+dataset/
+default.yaml
+dev.yaml
+mapping/
+default.yaml
+calibration/
+default.yaml
+adapter/
+pb_csa.yaml
+plstn.yaml
+hmv.yaml
+cec.yaml
+dtw_ta.yaml
+mtp.yaml
+fts.yaml
+hte.yaml
+wcv.yaml
+mfcc.yaml
+viz/
+default.yaml
+data/
+raw/
+scratch/
+docs/
+architecture.md
+adapters/
+PB-CSA.md
+PLSTN.md
+HMV.md
+CEC.md
+DTW-TA.md
+MTP.md
+FTS.md
+HTE.md
+WCV.md
+MFCC.md
+references.bib
+src/
+echopress/
+__init__.py
+cli.py
+
+# PEP 621 metadata; dependencies & tooling
+# project overview; quickstart
+# black/ruff/isort/mypy hooks
+# Hydra configs (hierarchical)
+# master config: paths, policies, defaults
+# dataset-related config group
+# root paths; timezone; timestamp grammar
+# overrides for small/dev runs
+# alignment policies and thresholds
+# O_max, tie_breaker, W, kappa...
+# alpha,beta; units; scalar_channel=3
+# choose adapter & hyperparams
+
+# plotting defaults; styles; limits
+# (user-provided path via config)
+# untouched raw inputs
+# OPTIONAL debug outputs only
+
+# if you build Sphinx/MkDocs w/ bib support
+# project package (importable)
+# Typer/Click entrypoints + Hydra main
+
+2
+
+types.py
+utils/
+__init__.py
+timeparse.py
+signals.py
+windows.py
+logging.py
+ingest/
+__init__.py
+indexer.py
+pstream.py
+ostream.py
+core/
+__init__.py
+calibration.py
+mapping.py
+derivative.py
+uncertainty.py
+tables.py
+adapters/
+__init__.py
+base.py
+pb_csa/
+adapter.py
+adapter.yml
+README.md
+tests/
+plstn/ ...
+hmv/
+cec/
+dtw_ta/
+mtp/
+fts/
+hte/
+wcv/
+mfcc/
+viz/
+__init__.py
+plot_signals.py
+plot_alignment.py
+plot_adapter.py
+styles.py
+export/
+__init__.py
+to_numpy.py
+datasets.py
+tests/
+test_ingest.py
+test_mapping.py
+test_derivative.py
+test_uncertainty.py
+
+# dataclasses / TypedDict Protocols
+# small helpers (time, signal, io)
+# parse M..-D..-H..-M..-S..-U.xxx
+# basic DSP utilities
+# tapers, resampling helpers
+# structlog or std logging config
+# walk folders; build registries
+# parse P-stream files to [(T^P, p)]
+# parse O-stream files to arrays + meta
+# p^(k)=alpha_k v^(k)+beta_k; scalar p=channel 3
+# midpoint alignment; E_align; tie-break
+# DerivEst (central/local-linear/savgol)
+# |P| <= kappa |dp/dt| * E_align
+# build in-memory tables (Signals, Map, ...)
+# unified adapter interface + library
+# Adapter Protocol; registry; validation
+
+# same pattern for each adapter
+
+# raw vs calibrated vs pressure overlay
+# show T_mid vs nearest T^P; errors
+# grid of adapter outputs, random by pressure
+
+# (X, y) in-memory build; optional save
+# Torch/TF-ready wrappers (future)
+# pytest suite
+
+3
+
+test_tables.py
+adapters/
+test_pb_csa.py
+test_plstn.py
+...
+test_mfcc.py
+
+4
+
+Configuration with Hydra (YAML)
+
+Master config conf/config.yaml
+defaults:
+- dataset: default
+- calibration: default
+- mapping: default
+- adapter: fts
+# choose active adapter group by default
+- viz: default
+- _self_
+run:
+seed: 1234
+num_workers: 0
+paths:
+data_root: ${dataset.data_root}
+pstream_glob: "${dataset.data_root}/raw/pstream/*.txt"
+ostream_glob: "${dataset.data_root}/raw/ostream/*.csv"
+tz: "UTC"
+
+Example conf/mapping/default.yaml
+O_max: 0.250
+# seconds
+tie_breaker: "earliest" # or "latest"
+W: 2.0
+# seconds, derivative window
+kappa: 1.0
+derivative:
+method: "central_diff"
+# local_linear | savgol
+min_records_in_W: 3
+reject_if_Ealign_gt_Omax: true
+
+Example adapter config conf/adapter/fts.yaml
+name: "fts"
+output_length: null
+segment:
+length: 2048
+hop: null
+detrend: "linear"
+window: "hann"
+normalize: "l2"
+
+# default = M/2+1 for real-valued segment
+# Ms
+# optional, if you want sliding segments
+# or "none"
+# none | l2 | dB_ref
+
+4
+
+5
+
+Typed Data Model (in-memory tables)
+
+Define simple, typed containers (Python dataclasses) to hold the information computed per
+file/record; keys ensure traceability:
+• OscFile: sid, files tamp(Tstart
+), NF , δtF , DF , TFmid .
+F
+• Signals:
+
+rows keyed by (sid, file_stamp, idx) with tF,n and channel amplitudes.
+
+• File2PressureMap:
+• AdapterVector:
+
+(sid, file_stamp, T P ∗ , p∗ , Ealign , |∆P |, Omax , W, κ).
+
+(sid, file_stamp, adapter_name, xF ∈ RL ).
+
+Skeleton (copy/paste)
+# src/echopress/types.py
+from dataclasses import dataclass
+from typing import Tuple, Optional, Dict, Any
+import numpy as np
+Key = Tuple[str, str]
+@dataclass(frozen=True)
+class OscFile:
+sid: str
+file_stamp: str
+N: int
+delta_t: float
+duration: float
+t_mid: float
+@dataclass
+class File2PressureMap:
+sid: str
+file_stamp: str
+p_time: float
+p_value: float
+E_align: float
+dP_bound: float
+O_max: float
+W: float
+kappa: float
+@dataclass
+class SignalsRow:
+sid: str
+file_stamp: str
+idx: int
+t_abs: float
+v: np.ndarray
+
+# (sid, file_stamp)
+
+# ISO8601-like or raw "M..-D..-H..-M..-S..-U.xxx"
+
+# absolute seconds since epoch
+
+# T^{P*}
+# p^*(F)
+
+# shape (C,), channel amplitudes
+
+@dataclass
+class AdapterVector:
+5
+
+sid: str
+file_stamp: str
+adapter: str
+x: np.ndarray
+
+6
+
+# shape (L,)
+
+Core Pipeline Modules (responsibilities & signatures)
+
+Ingest
+# src/echopress/ingest/indexer.py
+def index_dataset(p_glob: str, o_glob: str) -> Dict[str, Any]:
+"""Walk paths with pathlib, return dict of discovered P-stream/O-stream files,
+grouped by sid, with parsed timestamps and simple stats."""
+
+Pressure parsing, calibration
+# src/echopress/ingest/pstream.py
+def load_pstream(path: str, calib: Dict[str, Any]) -> np.ndarray:
+"""Return sorted array [(T^P_m, p_m)], with p_m = alpha_3*v^(3)+beta_3."""
+
+Oscilloscope loading
+# src/echopress/ingest/ostream.py
+def load_ostream_file(path: str) -> Tuple[np.ndarray, Dict[str, Any]]:
+"""Return (t_abs: (N,), v: (N,C)), plus meta (sid, start stamp, delta_t ...)."""
+
+Mapping, derivative, uncertainty
+# src/echopress/core/mapping.py
+def nearest_pressure(t_mid: float, P: np.ndarray, tie_breaker: str) -> Tuple[float,float]:
+"""Return (T^{P*}, p(T^{P*})) by nearest timestamp; break ties deterministically."""
+def align_error(t_start: float, N: int, delta_t: float, T_Pstar: float) -> float:
+"""E_align = | t_start + 0.5*N*delta_t - T^{P*} |"""
+
+# src/echopress/core/derivative.py
+def deriv_est(P: np.ndarray, T_Pstar: float, W: float, method: str, min_pts: int) -> float:
+"""Estimate dp/dt at T^{P*} with a window W, using method (central_diff, local_linear, sa
+# src/echopress/core/uncertainty.py
+def pressure_bound(dpdt: float, E_align: float, kappa: float) -> float:
+"""|P| <= kappa * |dp/dt| * E_align"""
+
+Tables assembly
+# src/echopress/core/tables.py
+def build_tables(...)-> Dict[str, Any]:
+"""Construct in-memory ’Signals’, ’OscFiles’, ’File2PressureMap’ from ingest+core."""
+
+6
+
+7
+
+Adapter Framework
+
+Interface & registry
+# src/echopress/adapters/base.py
+from typing import Protocol, Mapping
+import numpy as np
+class Adapter(Protocol):
+def name(self) -> str: ...
+def fit(self, v: np.ndarray, t: np.ndarray, cfg: Mapping) -> "Adapter": ...
+def transform(self, v: np.ndarray, t: np.ndarray, cfg: Mapping) -> np.ndarray: ...
+def fit_transform(self, v: np.ndarray, t: np.ndarray, cfg: Mapping) -> np.ndarray: ...
+ADAPTERS = {}
+
+# name -> constructor
+
+def register(name: str):
+def deco(cls):
+ADAPTERS[name] = cls
+return cls
+return deco
+
+Per-adapter folder contract
+Every adapter folder contains:
+• adapter.py (implements Adapter protocol, registers itself)
+• adapter.yml (hyperparameters)
+• README.md (theory, math, references)
+• tests/ (unit tests on synthetic signals)
+
+8
+
+Visualization Module
+
+# src/echopress/viz/plot_adapter.py
+def grid_by_pressure(adapter_name: str, pr_min: float, pr_max: float, n: int, seed: int, ...)
+"""Sample ’n’ files with p*(F) in [pr_min, pr_max], compute adapter vectors,
+and plot (or return) results. Supports --return_numpy to emit arrays."""
+
+9
+
+Export (on-demand, for ML)
+
+# src/echopress/export/to_numpy.py
+def build_xy(adapter_name: str, subset_keys=None, save: bool=False, path: str=None):
+"""Return X: (B, L), y: (B,), where B = number of files selected;
+If save=True, store NPZ for debugging; otherwise in-memory only."""
+
+10
+
+CLI Entrypoints (Hydra + Typer)
+
+# src/echopress/cli.py
+import typer
+import hydra
+7
+
+from omegaconf import DictConfig
+app = typer.Typer()
+@hydra.main(config_path="../../conf", config_name="config", version_base=None)
+def main(cfg: DictConfig):
+app()
+@app.command()
+def index():
+"""Index dataset and print summary."""
+@app.command()
+def align():
+"""Build tables with alignment, derivative, uncertainty."""
+@app.command()
+def adapt(adapter: str = typer.Option(...),
+pr_min: float = 0.0, pr_max: float = 300.0, n: int = 8,
+return_numpy: bool = False):
+"""Plot or return adapter outputs for random files within pressure range."""
+
+Example runs
+# index and alignment with defaults
+python -m echopress.cli index
+python -m echopress.cli align mapping.O_max=0.200 mapping.tie_breaker=latest
+# visualize 9 MFCC vectors for pressures in [80, 120] mmHg
+python -m echopress.cli adapt --adapter mfcc --pr-min 80 --pr-max 120 --n 9
+# build an in-memory dataset of (FTS, pressure)
+python -m echopress.cli adapt --adapter fts --return-numpy true
+
+11
+
+Loading Modes (memory vs. lazy)
+
+Default mode eagerly builds all tables in memory (fits dataset today). When data grows:
+• Batch iterators: wrap O-stream file iteration into generators yielding batches of files;
+tables are materialized per-batch for debugging and released after.
+• Selective subsetting: CLI flags to filter by sid, date ranges, or pressure bands before
+adapter computation.
+No persistent database is required; optional scratch artifacts (CSV/NPZ) can be emitted during
+debugging and then discarded.
+
+12
+
+Testing Strategy
+• Unit tests: ingest (parsing stamps), mapping (nearest time), derivative estimators (finitedifference truth), uncertainty bound monotonicity.
+• Adapter tests: synthetic signals with known spectra or periodicity to validate shape,
+invariance to circular shifts, and output dimension L.
+8
+
+• Property-based tests (optional): Hypothesis for shift-invariance (random circular shifts
+⇒ same features up to numerical tolerance).
+• Determinism: fixed random seeds; stable tie-breakers.
+
+13
+
+Minimal Per-Module README.md Snippets (copy/paste)
+
+Dataset Ingest (src/echopress/ingest/README.md)
+# Ingest Module
+Parses P-stream and O-stream files, builds in-memory registries.
+- P-stream: timestamp lines "M..-D..-H..-M..-S..-U.xxx" + voltage triple (V).
+- Calibrate p^(3) = alpha_3 v^(3) + beta_3.
+- O-stream: per-file uniform sampling with N_F and delta_t_F.
+Outputs:
+- OscFile table
+- Signals table (keyed by (sid, file_stamp, idx))
+- Ready for midpoint alignment and uncertainty bound.
+References: Oppenheim & Schafer (1989).
+
+Mapping & Uncertainty (src/echopress/core/README.md)
+# Mapping & Uncertainty
+
+For each O-stream file F:
+- Midpoint T_mid = T_start + 0.5 N_F delta_t_F.
+- Nearest P-stream timestamp T^{P*} by absolute difference; deterministic tie-break.
+- Alignment error E_align = |T_mid - T^{P*}|.
+- Derivative estimate dp/dt at T^{P*} using window W (central, local-linear, or Savitzky-Gola
+- Pressure bound: |P| <= kappa * |dp/dt| * E_align.
+Config: conf/mapping/default.yaml
+References: Oppenheim & Schafer (1989).
+
+Adapter Example: HMV (src/echopress/adapters/hmv/README.md)
+# Harmonic Magnitude Vector (HMV)
+Idea: Magnitudes at first H harmonics of estimated f0 yield a compact, shift-invariant
+representation (phase removed).
+Math:
+X(k) = | _n v[n] exp(-i 2 k f0 t[n]) |, k=1..H
+Feature vector x = [X(1), ..., X(H)] R^H.
+Config: adapter.yml (H, normalization, f0 estimation method).
+
+9
+
+Pros: robust to misalignment; compact.
+Cons: loses phase/shape.
+References: Oppenheim & Schafer (1989).
+
+Transform Example: FTS (src/echopress/adapters/fts/README.md)
+# Fourier Transform Spectrum (FTS)
+Idea: Use |DFT| magnitudes (first M/2+1 bins) for a length-M segment of v.
+Shift invariance: circular shift affects only phase → magnitudes unchanged.
+Config: segment.length (Ms), window, detrend, normalization.
+References: Oppenheim & Schafer (1989).
+
+Visualization (src/echopress/viz/README.md)
+# Visualization
+- plot_signals.py: raw channels vs. calibrated pressure overlay by absolute time.
+- plot_alignment.py: show T_mid vs nearest T^P (scatter), E_align histogram.
+- plot_adapter.py: grid of adapter outputs sampled by pressure range; return NumPy.
+CLI examples:
+python -m echopress.cli adapt --adapter mfcc --pr-min 80 --pr-max 120 --n 9
+
+14
+
+Best Practices (tooling & style)
+• Packaging: pyproject.toml with PEP 621; src/ layout; import as echopress.
+• Lint/Format/Type: ruff + black + isort + mypy via pre-commit.
+• Docs: Sphinx or MkDocs in docs/; math and references for each adapter.
+• Reproducibility: Hydra config composition; store resolved config in run dir; fixed seed.
+• Agnostic ML: expose numpy arrays; thin wrappers for Torch/TF added later.
+
+15
+
+State-of-the-Art, Scientifically Grounded Adapters (recap)
+• Cycle-synchronous: PB-CSA [1], PLSTN [2], HMV (Fourier series truncation) [3], CEC/cepstrum [4],
+DTW-TA [5], MTP/matched filter [6].
+• Transforms (time-domain inputs): FT spectrum [3], Hilbert-envelope [7], wavelets [8],
+MFCC [9].
+
+16
+
+Minimal End-to-End Flow (step list)
+
+1. Point conf/dataset/default.yaml to dataset root; set timestamp grammar/timezone.
+2. Index: python -m echopress.cli index.
+10
+
+3. Align: python -m echopress.cli align (build tables; compute Ealign , |∆P |).
+4. Inspect: python -m echopress.cli adapt –adapter fts –pr-min 80 –pr-max 120 –n
+12.
+5. Export (on-demand): python -m echopress.cli adapt –adapter mfcc –return-numpy
+true.
+6. Debug: toggle Hydra overrides for thresholds/hyperparameters; run unit tests with pytest
+-q.
+
+References
+References
+[1] S. Braun, The Extraction of Periodic Waveforms by Time Domain Averaging, Acustica
+32(2), 69–77 (1975).
+[2] P. D. McFadden, Interpolation techniques for time domain averaging of gear vibration,
+Mechanical Systems and Signal Processing 3(1), 87–97 (1989).
+[3] A. V. Oppenheim and R. W. Schafer, Discrete-Time Signal Processing, Prentice Hall (1989).
+[4] A. M. Noll, Cepstrum pitch determination, J. Acoust. Soc. Am. 41(2), 293–309 (1967).
+[5] H. Sakoe and S. Chiba, Dynamic programming algorithm optimization for spoken word
+recognition, IEEE Trans. Acoust. Speech Signal Process. 26(1), 43–49 (1978).
+[6] G. L. Turin, An introduction to matched filters, IRE Trans. Information Theory 6(3), 311–
+329 (1960).
+[7] S. O. Sadjadi and J. H. L. Hansen, Hilbert envelope based features for robust speaker identification under reverberant mismatched conditions, Proc. IEEE ICASSP, 5448–5451 (2011).
+[8] G. Tzanetakis, G. Essl, and P. Cook, Audio analysis using the discrete wavelet transform,
+Proc. WSES Int. Conf. Acoustics & Music Theory & Applications, Skiathos, Greece (2001).
+[9] S. B. Davis and P. Mermelstein, Comparison of parametric representations for monosyllabic word recognition in continuously spoken sentences, IEEE Trans. Acoust. Speech Signal
+Process. 28(4), 357–366 (1980).
+
+11
+
+

--- a/src/echopress/adapters/cec/README.md
+++ b/src/echopress/adapters/cec/README.md
@@ -1,14 +1,13 @@
-# cec Adapter
+# CEC Adapter
 
-Example Hydra configuration:
+The Cepstral Envelope Coefficients (CEC) adapter is a first-layer method that captures the spectral envelope of a periodic signal using low-quefrency cepstral coefficients [Plan].
 
-```yaml
-adapter:
-  name: cec
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Compute the log-magnitude spectrum of the waveform and take its inverse Fourier transform to obtain the real cepstrum $C(q)$.
+2. Collect the first $Q$ low-quefrency coefficients $c_q$ as the feature vector $x_F=[c_1,\ldots,c_Q]$.
+3. Because coefficients depend only on the magnitude spectrum, the representation is shift-invariant and robust to noise [Theory].
 
-This adapter is a placeholder implementation.
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- A. M. Noll, "Cepstrum pitch determination," *J. Acoust. Soc. Am.* 41(2), 293–309 (1967).

--- a/src/echopress/adapters/cec/adapter.yml
+++ b/src/echopress/adapters/cec/adapter.yml
@@ -1,2 +1,3 @@
 name: cec
-description: Placeholder adapter
+description: Cepstral Envelope Coefficients adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/cec/tests/test_adapter.py
+++ b/src/echopress/adapters/cec/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the CEC adapter.
+
+See ``README.md`` for theoretical motivation and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/dtw_ta/README.md
+++ b/src/echopress/adapters/dtw_ta/README.md
@@ -1,14 +1,15 @@
-# dtw_ta Adapter
+# DTW-TA Adapter
 
-Example Hydra configuration:
+The Dynamic Time Warping Template Average (DTW-TA) adapter aligns each detected cycle of the waveform to a reference template using constrained DTW and averages the aligned cycles. It is a first-layer cycle-synchronous mapping [Plan].
 
-```yaml
-adapter:
-  name: dtw_ta
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Build an initial template from a few cycles or another adapter output.
+2. Align each cycle to the template via constrained DTW (e.g., Sakoe–Chiba band) and resample to a common length $M$.
+3. Robust-average the aligned cycles to produce $x_F \in \mathbb{R}^M$.
 
-This adapter is a placeholder implementation.
+This procedure handles cycle length drift and shape variability while preserving shift invariance through alignment [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- H. Sakoe and S. Chiba, "Dynamic programming algorithm optimization for spoken word recognition," *IEEE Trans. Acoust. Speech Signal Process.* 26(1), 43–49 (1978).

--- a/src/echopress/adapters/dtw_ta/adapter.yml
+++ b/src/echopress/adapters/dtw_ta/adapter.yml
@@ -1,2 +1,3 @@
 name: dtw_ta
-description: Placeholder adapter
+description: Dynamic Time Warping Template Average adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/dtw_ta/tests/test_adapter.py
+++ b/src/echopress/adapters/dtw_ta/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the DTW-TA adapter.
+
+See ``README.md`` for the alignment theory and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/fts/README.md
+++ b/src/echopress/adapters/fts/README.md
@@ -1,14 +1,13 @@
-# fts Adapter
+# FTS Adapter
 
-Example Hydra configuration:
+The Fourier Transform Spectrum (FTS) adapter belongs to the repository's second layer of transform-based mappings, providing a shift-invariant magnitude spectrum representation [Plan].
 
-```yaml
-adapter:
-  name: fts
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+Given a time series $v_n$, compute the discrete Fourier transform
+$$X(k)=\sum_{n=0}^{M-1} v_n e^{-i2\pi kn/M},\quad k=0,\ldots,M-1.$$
+The feature vector consists of the magnitudes $|X(k)|$ (typically the first $M/2+1$ values for real signals). A circular time shift affects only phase, leaving magnitudes unchanged [Theory].
 
-This adapter is a placeholder implementation.
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- A. V. Oppenheim and R. W. Schafer, *Discrete-Time Signal Processing*, Prentice Hall (1989).

--- a/src/echopress/adapters/fts/adapter.yml
+++ b/src/echopress/adapters/fts/adapter.yml
@@ -1,2 +1,3 @@
 name: fts
-description: Placeholder adapter
+description: Fourier Transform Spectrum adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/fts/tests/test_adapter.py
+++ b/src/echopress/adapters/fts/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the FTS adapter.
+
+See ``README.md`` for spectral theory and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/hmv/README.md
+++ b/src/echopress/adapters/hmv/README.md
@@ -1,14 +1,16 @@
-# hmv Adapter
+# HMV Adapter
 
-Example Hydra configuration:
+The Harmonic Magnitude Vector (HMV) adapter is a first-layer cycle-synchronous method that summarizes a signal by the magnitudes of its first $H$ harmonics of the fundamental frequency [Plan].
 
-```yaml
-adapter:
-  name: hmv
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Estimate $f_0$ and compute
+   $$X(k)=\sum_n v_{F,n} e^{-i2\pi k f_0 t_{F,n}},\quad k=1,\ldots,H$$
+   where $v_{F,n}$ are samples of the waveform.
+2. Form the feature vector $x_F=[|X(1)|,\ldots,|X(H)|]$.
 
-This adapter is a placeholder implementation.
+Magnitudes remove phase, yielding shift invariance [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- A. V. Oppenheim and R. W. Schafer, *Discrete-Time Signal Processing*, Prentice Hall (1989).

--- a/src/echopress/adapters/hmv/adapter.yml
+++ b/src/echopress/adapters/hmv/adapter.yml
@@ -1,2 +1,3 @@
 name: hmv
-description: Placeholder adapter
+description: Harmonic Magnitude Vector adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/hmv/tests/test_adapter.py
+++ b/src/echopress/adapters/hmv/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the HMV adapter.
+
+See ``README.md`` for theoretical details and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/hte/README.md
+++ b/src/echopress/adapters/hte/README.md
@@ -1,14 +1,14 @@
-# hte Adapter
+# HTE Adapter
 
-Example Hydra configuration:
+The Hilbert Transform Envelope (HTE) adapter computes the analytic signal and extracts its amplitude envelope, yielding a shift-invariant representation of modulation patterns. It is part of the second-layer transform adapters [Plan].
 
-```yaml
-adapter:
-  name: hte
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Form the analytic signal $a(t)=v(t)+i\,\mathcal{H}\{v(t)\}$ using the Hilbert transform $\mathcal{H}\{\cdot\}$.
+2. Take the envelope $e(t)=|a(t)|$ and optionally rotate or summarize it to obtain a fixed-length vector $x_F$.
 
-This adapter is a placeholder implementation.
+Because the envelope discards the carrier phase, it is insensitive to global time shifts [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- S. O. Sadjadi and J. H. L. Hansen, "Hilbert envelope based features for robust speaker identification under reverberant mismatched conditions," in *Proc. IEEE ICASSP*, 5448–5451 (2011).

--- a/src/echopress/adapters/hte/adapter.yml
+++ b/src/echopress/adapters/hte/adapter.yml
@@ -1,2 +1,3 @@
 name: hte
-description: Placeholder adapter
+description: Hilbert Transform Envelope adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/hte/tests/test_adapter.py
+++ b/src/echopress/adapters/hte/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the HTE adapter.
+
+See ``README.md`` for envelope theory and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/mfcc/README.md
+++ b/src/echopress/adapters/mfcc/README.md
@@ -1,14 +1,16 @@
-# mfcc Adapter
+# MFCC Adapter
 
-Example Hydra configuration:
+The Mel-Frequency Cepstral Coefficients (MFCC) adapter computes log-energy in mel-spaced frequency bands followed by a discrete cosine transform, producing a compact, shift-invariant spectral envelope. It is part of the second-layer transform adapters [Plan].
 
-```yaml
-adapter:
-  name: mfcc
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Filter the magnitude spectrum into $B$ mel bands and compute energies $E_k$.
+2. Take logarithms $Y_k = \ln E_k$ and apply the discrete cosine transform
+   $$c_m = \sum_{k=1}^{B} Y_k \cos\left[\frac{\pi m}{B}(k-0.5)\right],\quad m=1,\ldots,M.$$
+3. Use the first $M$ coefficients $c_m$ as the feature vector $x_F$.
 
-This adapter is a placeholder implementation.
+Because only spectral magnitudes are used, the features are invariant to global shifts [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- S. B. Davis and P. Mermelstein, "Comparison of parametric representations for monosyllabic word recognition in continuously spoken sentences," *IEEE Trans. Acoust. Speech Signal Process.* 28(4), 357–366 (1980).

--- a/src/echopress/adapters/mfcc/adapter.yml
+++ b/src/echopress/adapters/mfcc/adapter.yml
@@ -1,2 +1,3 @@
 name: mfcc
-description: Placeholder adapter
+description: Mel-Frequency Cepstral Coefficients adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/mfcc/tests/test_adapter.py
+++ b/src/echopress/adapters/mfcc/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the MFCC adapter.
+
+See ``README.md`` for spectral-envelope theory and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/mtp/README.md
+++ b/src/echopress/adapters/mtp/README.md
@@ -1,14 +1,16 @@
-# mtp Adapter
+# MTP Adapter
 
-Example Hydra configuration:
+The Matched-Template Projection (MTP) adapter projects the waveform onto a known canonical template and reports the best-fit amplitude or coefficients. It is included in the first layer of cycle-synchronous mappings [Plan].
 
-```yaml
-adapter:
-  name: mtp
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Assume a reference pattern $z(t)$ shared across files.
+2. Estimate amplitude $a$ and shift $\tau$ by solving
+   $$ (\hat a, \hat\tau) = \arg\min_{a,\tau} \sum_n \left(v_{F,n} - a\, z(t_{F,n}-\tau)\right)^2 $$
+3. Use $\hat a$ or projection coefficients $\langle v_F, z_k \rangle$ as features $x_F$.
 
-This adapter is a placeholder implementation.
+Encoding only amplitudes yields shift-invariant, compact descriptors when the template is accurate [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- G. L. Turin, "An introduction to matched filters," *IRE Trans. Information Theory* 6(3), 311–329 (1960).

--- a/src/echopress/adapters/mtp/adapter.yml
+++ b/src/echopress/adapters/mtp/adapter.yml
@@ -1,2 +1,3 @@
 name: mtp
-description: Placeholder adapter
+description: Matched-Template Projection adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/mtp/tests/test_adapter.py
+++ b/src/echopress/adapters/mtp/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the MTP adapter.
+
+See ``README.md`` for the matched-filter formulation and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/pb_csa/README.md
+++ b/src/echopress/adapters/pb_csa/README.md
@@ -1,14 +1,16 @@
-# pb_csa Adapter
+# PB-CSA Adapter
 
-Example Hydra configuration:
+The Phase-Bin Cycle-Synchronous Averaging (PB-CSA) adapter is a first-layer, cycle-synchronous mapping that folds each waveform by phase and averages across cycles to form a fixed-length vector [Plan].
 
-```yaml
-adapter:
-  name: pb_csa
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Estimate the fundamental period $T_0$ and compute sample phases
+   $\theta_n = 2\pi (t_{F,n} \bmod T_0)/T_0$ [Theory].
+2. Partition the phase domain into $K$ bins $\Theta_k$ and aggregate samples in each bin using a robust statistic such as the mean or median [Theory].
+3. Circularly shift the resulting vector so a reference phase is centered, ensuring approximate shift invariance [Theory].
 
-This adapter is a placeholder implementation.
+The output is $x_F \in \mathbb{R}^K$, where $K$ is the number of phase bins.
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- S. Braun, "The Extraction of Periodic Waveforms by Time Domain Averaging," *Acustica* 32(2), 69–77 (1975).

--- a/src/echopress/adapters/pb_csa/adapter.yml
+++ b/src/echopress/adapters/pb_csa/adapter.yml
@@ -1,2 +1,3 @@
 name: pb_csa
-description: Placeholder adapter
+description: Phase-Bin Cycle-Synchronous Averaging adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/pb_csa/tests/test_adapter.py
+++ b/src/echopress/adapters/pb_csa/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the PB-CSA adapter.
+
+See ``README.md`` for algorithmic theory and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/plstn/README.md
+++ b/src/echopress/adapters/plstn/README.md
@@ -1,14 +1,13 @@
-# plstn Adapter
+# PLSTN Adapter
 
-Example Hydra configuration:
+The Peak-Locked Segmentation & Time Normalization (PLSTN) adapter is part of the first layer of cycle-synchronous, shift-invariant mappings [Plan]. It centers windows on detected peaks, normalizes each cycle to a common length, and aggregates them.
 
-```yaml
-adapter:
-  name: plstn
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Detect peak indices $\{n_j\}$ with a refractory period near $T_0$.
+2. For each cycle window $W_j=[n_j-w_-, n_j+w_+]$, resample to $M$ points using bandlimited or cubic interpolation.
+3. Robust-average the normalized cycles to obtain $x_F \in \mathbb{R}^M$.
 
-This adapter is a placeholder implementation.
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- P. D. McFadden, "Interpolation techniques for time domain averaging of gear vibration," *Mechanical Systems and Signal Processing* 3(1), 87–97 (1989).

--- a/src/echopress/adapters/plstn/adapter.yml
+++ b/src/echopress/adapters/plstn/adapter.yml
@@ -1,2 +1,3 @@
 name: plstn
-description: Placeholder adapter
+description: Peak-Locked Segmentation & Time Normalization adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/plstn/tests/test_adapter.py
+++ b/src/echopress/adapters/plstn/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the PLSTN adapter.
+
+See ``README.md`` for theoretical background and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/src/echopress/adapters/wcv/README.md
+++ b/src/echopress/adapters/wcv/README.md
@@ -1,14 +1,15 @@
-# wcv Adapter
+# WCV Adapter
 
-Example Hydra configuration:
+The Wavelet Coefficient Vector (WCV) adapter summarizes energy across wavelet scales and is part of the second-layer transform adapters [Plan].
 
-```yaml
-adapter:
-  name: wcv
-  output_length: 0
-  period_est:
-    fs: 10.0
-    f0: 2.0
-```
+## Algorithm
+1. Apply a discrete wavelet transform to obtain approximation coefficients $A_J$ and detail coefficients $D_j$ for scales $j=1,\ldots,J$.
+2. Compute subband energies $E_j = \sum_n |D_j[n]|^2$ and optionally include $\|A_J\|_2^2$.
+3. Form the feature vector $x_F=[E_1,\ldots,E_J,\|A_J\|_2^2]$.
 
-This adapter is a placeholder implementation.
+Using stationary or energy-pooled coefficients provides approximate shift invariance [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- G. Tzanetakis, G. Essl, and P. Cook, "Audio analysis using the discrete wavelet transform," in *Proc. WSES Int. Conf. Acoustics & Music Theory & Applications*, Skiathos, Greece (2001).

--- a/src/echopress/adapters/wcv/adapter.yml
+++ b/src/echopress/adapters/wcv/adapter.yml
@@ -1,2 +1,3 @@
 name: wcv
-description: Placeholder adapter
+description: Wavelet Coefficient Vector adapter. See README.md for theory and references.
+docs: README.md

--- a/src/echopress/adapters/wcv/tests/test_adapter.py
+++ b/src/echopress/adapters/wcv/tests/test_adapter.py
@@ -1,3 +1,8 @@
+"""Tests for the WCV adapter.
+
+See ``README.md`` for wavelet theory and references.
+"""
+
 from echopress.adapters import get_adapter
 import numpy as np
 

--- a/theory.txt
+++ b/theory.txt
@@ -1,0 +1,769 @@
+Raw Dataset Specification: Pressure & Oscilloscope Streams
+with File-Level Midpoint Alignment and Configurable
+Uncertainty
+
+1
+
+Overview: Two Unsynchronized Measurements
+
+The data comprise two streams recorded by different, unsynchronized devices:
+• Pressure stream (P-stream): per-record global timestamp followed by a voltage triple
+(v (1) , v (2) , v (3) ). Each column maps linearly to pressure, but the canonical scalar is only
+channel 3.
+• Oscilloscope stream (O-stream): per file, a time series with NF samples, uniform sampling interval δtF , and amplitudes (channels) collected as v F,n .
+Because the devices are not synchronized, each O-stream file F receives a single scalar pressure
+label by aligning its file midpoint time to the nearest P-stream global timestamp.
+
+2
+
+Pressure Stream (P-stream)
+
+2.1
+
+Per-Record Structure
+
+Each record consists of:
+1. A global timestamp line of the form
+M |{z}
+MM -D |{z}
+DD -H |{z}
+HH -M |{z}
+mm -S |{z}
+SS -U. |{z}
+uuu ,
+month
+
+day
+
+minute
+
+hour
+
+second
+
+subsecond
+
+e.g., M08-D19-H16-M24-S03-U.128. Parsing τ (·) yields absolute time T P ∈ R (seconds).
+2. Immediately followed by a voltage triple:
+v (1)
+
+v (2)
+
+v (3)
+
+(in volts).
+
+For k ∈ {1, 2, 3}, linear calibration is
+p(k) = αk v (k) + βk .
+The canonical scalar pressure is only channel 3 :
+p = p(3) = α3 v (3) + β3 .
+(3)
+
+P , p )}M
+We denote the P-stream as P = {(Tm
+m m=1 with pm = α3 vm + β3 .
+
+1
+
+3
+
+Oscilloscope Stream (O-stream)
+
+3.1
+
+Per-File Structure and Timing
+
+Each oscilloscope file F carries a session ID and an embedded global timestamp, e.g.,
+itid0notrig3M08-D19-H16-M24-S43-U.788.csv.
+We parse F ≡ (sid, stamp, ext) and set TFstart = τ (stamp). Within the file, we have a uniform
+series of length NF with sampling interval δtF :
+tF,n = TFstart + n δtF ,
+
+n = 0, 1, . . . , NF − 1.
+
+Let DF = NF δtF be the duration and
+TFmid = TFstart + 21 DF .
+
+4
+
+(1)
+
+File-Level Mapping to Pressure (Nearest Timestamp)
+
+For each O-stream file F , map its midpoint time to the nearest P-stream timestamp:
+T P∗ (F ) ∈ arg
+
+min
+
+P ∈{T P ,...,T P }
+Tm
+1
+M
+
+P
+TFmid − Tm
+.
+
+(2)
+
+The associated scalar pressure label is p∗ (F ) = p evaluated at T P∗ (F ).
+Alignment error and acceptance. Define the file-level alignment error
+Ealign (F ) =
+
+TFstart + 21 NF δtF − T P∗ (F ) .
+
+(3)
+
+Mapping is accepted if Ealign (F ) ≤ Omax , where Omax > 0 is provided in the external configuration file.
+
+5
+
+Pressure Error from Mapping Mismatch
+
+Let p(t) denote the scalar pressure trajectory from channel 3. We estimate its local derivative
+at the matched time using a configurable window size W (from the configuration file) around
+T P∗ (F ).
+Derivative estimator (configurable window W ). Define the slope estimator at T P∗ (F ) as
+
+
+ḃ
+pW T P∗ (F ) ≡ DerivEst P; T P∗ (F ), W ,
+(4)
+where DerivEst is a user-selected method (e.g., central difference, local linear regression) over
+the window of temporal width W centered at T P∗ (F ).
+Uncertainty multiplier. Let κ ≥ 0 be a user-provided multiplier that scales the bound
+conservatively.
+Pressure uncertainty bound. The induced pressure inaccuracy for file F due to alignment
+error (3) is
+
+|∆P (F )| ≤ κ ḃ
+pW T P∗ (F ) · Ealign (F ).
+(5)
+Equation (4) (“Eq. 4”) explicitly states that the derivative is estimated using the input window
+W . Reference macro: Eq. (4).
+2
+
+6
+
+Relational Materialization for ML
+
+For downstream ML, a single tall table is sufficient; a normalized mapping is optional.
+
+Option A: Single Tall Table
+
+Signals
+
+sid
+|{z}
+
+session/run ID
+
+N , delta_t, duration
+, file_stamp, |{z}
+idx , t_abs, v (channels), |{z}
+, t_mid, p_time,
+| {z } | {z } | {z } | {z }
+| {z }
+|
+{z
+}
+TFstart
+
+n
+
+NF
+
+tF,n
+
+δtF
+
+DF
+
+TFmid
+
+T P∗ (F )
+
+p
+|{z}
+
+p∗ (F )=p(3)
+
+, O_
+|
+
+O
+
+Primary key: (sid, file_stamp, idx).
+
+Option B: Normalized Mapping
+OscFiles(sid, file_stamp, N, δt, duration, t_mid)
+File2PressureMap(sid, file_stamp, p_time = T P∗ , p = p∗ , O_max, W, kappa, E_align, dP_bound)
+Signals(sid, file_stamp, idx, t_abs, v)
+
+7
+
+External Configuration File: dataset_config.yml
+
+All missing inputs and policy choices are centralized in a YAML file that ships with the
+dataset/repo.
+
+7.1
+
+YAML Schema (math semantics)
+
+Key
+
+Type
+
+Meaning / Math Symbol
+
+calibration.alpha
+calibration.beta
+pressure.scalar_channel
+units.pressure
+units.voltage
+timestamp.format
+timestamp.subsec_unit
+timestamp.timezone
+mapping.tie_breaker
+mapping.O_max
+derivative.method
+derivative.W
+uncertainty.kappa
+quality.min_records_in_W
+
+list[float] (len 3)
+list[float] (len 3)
+int
+str
+str
+str
+str
+str
+enum
+float (s)
+enum
+float (s)
+float
+int
+
+quality.reject_if_Ealign_gt_Omax
+defaults.year_fallback
+
+bool
+int
+
+Per-channel slopes (α1 , α2 , α3 ).
+Per-channel intercepts (β1 , β2 , β3 ).
+Channel index used for scalar pressure (must be 3).
+Pressure unit (e.g., mmHg).
+Voltage unit (e.g., V).
+Stamp grammar/pattern for parser τ (·).
+Subsecond unit for U. field (e.g., ms or us).
+Time zone assumption for stamps.
+Nearest-timestamp tie policy (earliest|latest).
+Max acceptable alignment error Omax (seconds).
+DerivEst type (central_diff|local_linear|savgol
+Window width W used in Eq. (4).
+Multiplier κ used in Eq. (5).
+Minimum P-stream points inside W to accept slop
+estimate.
+If true, discard file when Ealign > Omax .
+Year to use if missing on lines (overridden by fi
+name).
+
+7.2
+
+YAML Example (to include in repo as dataset_config.yml)
+
+calibration:
+alpha: [a1, a2, a3]
+beta: [b1, b2, b3]
+pressure:
+scalar_channel: 3
+
+# slopes for channels 1..3
+# intercepts for channels 1..3
+# must be 3
+3
+
+units:
+pressure: "mmHg"
+voltage: "V"
+timestamp:
+format: "M%02d-D%02d-H%02d-M%02d-S%02d-U.%03d"
+subsec_unit: "ms"
+# or "us"
+timezone: "UTC"
+mapping:
+tie_breaker: "earliest"
+# or "latest"
+O_max: 0.250
+# seconds (example)
+derivative:
+method: "central_diff"
+# or "local_linear", "savgol"
+W: 2.0
+# seconds; window centered at T^{P*}(F)
+uncertainty:
+kappa: 1.0
+# conservative multiplier
+quality:
+min_records_in_W: 3
+# require >=3 P-stream points in window
+reject_if_Ealign_gt_Omax: true
+defaults:
+year_fallback: 2025
+Semantics.
+• Scalar pressure is p = α3 v (3) + β3 ; channels 1,2 may be retained as auxiliary.
+• Alignment follows Eq. (2); error via Eq. (3); acceptance threshold Omax from the YAML.
+• The slope estimator in Eq. (4) uses the window W and method specified in derivative.
+• The uncertainty bound in Eq. (5) uses κ from uncertainty.
+• If reject_if_Ealign_gt_Omax is true and Ealign (F ) > Omax , the file F is excluded or
+flagged.
+
+8
+
+Integrity Constraints & Sanity Checks
+1. Units: voltages in V; pressures in mmHg; (αk , βk ) must be unit-consistent.
+2. Scalar channel: the only scalar pressure used downstream is p(3) .
+3. O-stream timing: tF,n = TFstart + nδtF ; DF = NF δtF ; TFmid as in Eq. (1).
+4. Mapping rule: Eq. (2); error Eq. (3); accept iff Ealign (F ) ≤ Omax .
+5. Derivative window: Eq. (4) uses window W from the YAML config.
+6. Uncertainty bound: Eq. (5) with multiplier κ; store dP_bound.
+7. Determinism: fixed tie-breaking policy for nearest timestamp (YAML mapping.tie_breaker).
+
+9
+
+Minimal Examples
+
+Pressure record (P-stream)
+M08-D19-H16-M24-S03-U.128
+2.427 1.092 6.266
+4
+
+Parsed at T P = τ (“M08-D19-H16-M24-S03-U.128”) with p = α3 · 6.266 + β3 .
+
+Oscilloscope file (O-stream)
+itid0notrig3M08-D19-H16-M24-S43-U.788.csv
+Set TFstart = τ (“M08-D19-H16-M24-S43-U.788”), compute DF = NF δtF , TFmid via Eq. (1), find
+T P∗ (F ) by Eq. (2), Ealign (F ) by Eq. (3), accept if ≤ Omax , and set p∗ (F ) = p at T P∗ (F ) with
+uncertainty bound Eq. (5).
+
+Adapters: Mapping (t, v, δt) to ML-Ready Vectors
+
+10
+
+F −1
+Each adapter A maps the oscilloscope file F with time series {(tF,n , vF,n )}N
+n=0 to a fixed-length
+vector
+xF ∈ RL (independent of NF and invariant to time shifts).
+
+Adapters may depend on an estimated fundamental period T0 (or f0 = 1/T0 ) and configuration
+parameters supplied in dataset_config.yml.
+
+10.1
+
+Adapter API
+
+Given F , configuration Γ, and (optionally) a prior T0 ,
+xF , QF = A(F ; Γ, T0 ) ,
+where QF are quality diagnostics (e.g., cycles used, SNR gain, detection confidence). Each
+adapter must:
+1. produce a fixed length L (set in Γ),
+2. be (approximately) invariant to global time shift of vF,· ,
+3. remain comparable across files with different pulse counts (NF varies).
+
+10.2
+
+Cycle/Period Detection Options (shared prelude)
+
+Before any adapter, we may estimate T0 using one (or combine several) of:
+P
+• Autocorrelation peak: T̂0 ∈ arg maxτ ∈T n vF,n vF,n+τ .
+• Cepstrum: T̂0 at the dominant quefrency peak of C(q) = F −1 {log |F{v}|2 }.
+• Spectral peak: fˆ0 = arg max peak in |F{v}|; T0 = 1/fˆ0 .
+• Fiducial peaks: robust peak picking with amplitude threshold + refractory period near
+T̂0 .
+Quality gates (min peak ratio, min SNR) guard against spurious periodicity.
+
+5
+
+10.3
+
+Adapter A: Phase-Bin Cycle-Synchronous Averaging (PB-CSA)
+
+Idea: Fold samples by phase then average across cycles (super-res in phase).
+1. Estimate T̂0 ; define phase θn = 2π (tF,n mod T̂0 )/T̂0 .
+2. Choose phase bins Θk = [2π(k − 1)/K, 2πk/K), k = 1..K.
+3. Aggregate xk = Aggr{ vF,n : θn ∈ Θk } using mean/median/trimmed-mean.
+4. Shift invariance: rotate so the maximal bin is centered (circular shift) or anchor to a
+fiducial (e.g., rising-edge phase).
+Output: xF ∈ RK (set L = K). Notes: Large K gives phase super-resolution by multi-cycle
+dithering. Require min counts per bin; adapt K if needed. Cycle-synchronous averaging is a
+classical approach for periodic signal enhancement [1].
+
+10.4
+
+Adapter B: Peak-Locked Segmentation & Time Normalization (PLSTN)
+
+Idea: Cut windows around detected peaks, normalize each cycle to M samples, then robustaverage.
+1. Detect peak indices {nj } with refractory ≈ T̂0 .
+2. For each cycle window Wj = [nj − w− , nj + w+ ], resample to M points via bandlimited
+(sinc) or cubic interpolation.
+3. Robust-average across cycles (median / Huber) to get xF ∈ RM .
+Shift invariance: windows are peak-centered. Pros: faithful time-domain shape. Cons: sensitive to missed/false peaks. Notes: Resampling each cycle to a fixed length can compensate for
+slight period variations (e.g., due to speed fluctuations) [2].
+
+10.5
+
+Adapter C: Harmonic Magnitude Vector (HMV)
+
+Idea: Represent the signal by magnitudes at the first H harmonics of fˆ0 .
+X(k) =
+
+X
+
+ˆ
+
+vF,n e−i2πkf0 tF,n ,
+
+k = 1..H,
+
+xF = [X(1), . . . , X(H)].
+
+n
+
+Shift invariance: magnitudes remove phase. Optionally normalize by DC or ℓ2 norm. Pros:
+compact, robust to misalignment. Cons: loses waveform phase/shape details. Notes: Using a
+limited set of harmonic amplitudes is essentially a truncated Fourier series representation of the
+periodic signal [3].
+
+10.6
+
+Adapter D: Cepstral Envelope Coefficients (CEC)
+
+Idea: Use low-quefrency cepstral coefficients to capture periodic envelope.
+
+
+xF = c1 , . . . , cQ , where cq are first Q coefficients of C(q).
+Shift invariance: by construction (depends on magnitude spectrum). Pros: noise-robust;
+detects periodicity. Cons: less interpretable in time domain. Notes: Cepstral analysis was
+introduced for echo and pitch detection in acoustics [4], and low-quefrency coefficients (similar
+to MFCCs) are widely used to represent spectral envelope.
+
+6
+
+10.7
+
+Adapter E: DTW-Template Average (DTW-TA)
+
+Idea: Align each detected cycle to a reference waveform via constrained DTW, resample to M ,
+robust-average.
+1. Build a provisional template (median of a few cycles or from PB-CSA).
+2. Constrained DTW (Sakoe–Chiba band) to warp each cycle to template length M .
+3. Robust-average the aligned cycles ⇒ xF ∈ RM .
+Shift invariance: implicit via alignment. Pros: handles cycle length drift/shape variability.
+Cons: heavier compute; risk of over-warping noise. Notes: Dynamic time warping is a classic
+method for sequence alignment (originating in speech recognition) [5], and can be leveraged to
+compute an average waveform across cycles.
+
+10.8
+
+Adapter F: Matched-Template Projection (MTP)
+
+Idea: If a known canonical periodic pattern z(t) exists (identical across files), estimate shift/scale
+and project onto z.
+X
+2
+(â, τ̂ ) = arg min
+vF,n − a z(tF,n − τ ) ,
+a,τ
+
+
+
+xF = â,
+
+n
+
+⟨vF , zk ⟩
+| {z }
+
+
+, ... .
+
+optional multi-basis
+
+Shift invariance: encode only â or coefficients in the pattern basis; drop τ̂ for invariance. Pros:
+very compact; high SNR when template is accurate. Cons: requires a reliable z(t). Notes: This
+approach parallels the matched filter concept in signal processing [6], where a known template
+is used to detect and quantify a signal of interest.
+
+10.9
+
+Boosting Resolution and Robustness (shared tricks)
+
+• Interpolation: prefer bandlimited/sinc (best fidelity), cubic as lighter fallback.
+• Robust aggregation: median or trimmed-mean (e.g., 10%) to suppress outlier cycles.
+• Adaptive resolution: choose K or M so that expected samples/bin ≥ cmin ; otherwise
+reduce K or merge bins.
+• Normalization (optional): RMS or peak normalization per cycle when amplitude should
+not encode label; leave in absolute units when it should.
+√
+• SNR gain: cycle averaging boosts SNR by ≈ Jeff where Jeff is the number of nonrejected cycles.
+
+10.10
+
+Choosing an Adapter (summary)
+
+Adapter
+
+Output
+
+Shift Inv.
+
+Pros
+
+Cons
+
+PB-CSA
+PLSTN
+HMV
+CEC
+DTW-TA
+MTP
+
+K phase bins
+M samples
+H mags
+Q coeffs
+M samples
+few scalars
+
+via circular align
+peak-centered
+by magnitude
+yes
+via warping
+by design
+
+super-res phase; fast
+faithful waveform
+compact; robust
+noise-robust
+handles drift
+very compact
+
+needs good T0
+peak sensitivity
+loses phase/shape
+less interpretable
+compute heavy
+needs template
+
+7
+
+10.11
+
+Quality Diagnostics (recommended to store)
+
+For each F , store: cycles detected/used (J, Jeff ), detection SNR, min counts/bin (PB-CSA),
+rejected cycle ratio, interpolation method, and an instability flag (e.g., period variance over
+windows).
+
+11
+
+YAML Extensions: Adapter Selection & Hyperparameters
+
+Key
+
+Type
+
+Meaning
+
+adapter.name
+adapter.output_length
+adapter.period_est.method
+adapter.period_est.search_range
+adapter.pb_csa.K
+adapter.pb_csa.aggregator
+adapter.pb_csa.min_bin_count
+adapter.plstn.M
+adapter.plstn.window
+adapter.plstn.interp
+adapter.hmv.H
+adapter.cec.Q
+adapter.dtw_ta.band
+adapter.mtp.template_path
+adapter.normalization
+adapter.reject_outlier_cycles
+adapter.trim_fraction
+adapter.seed
+
+enum
+int
+enum
+[float,float] (s)
+int
+enum
+int
+int
+[int,int]
+enum
+int
+int
+float
+str
+enum
+bool
+float
+int
+
+pb_csa | plstn | hmv | cec | dtw_ta | mtp.
+L (i.e., K or M or H or Q).
+autocorr | cepstrum | spectral | peaks | hybrid.
+plausible T0 bounds.
+# phase bins (if pb_csa).
+mean | median | trimmed_mean.
+minimum samples per phase bin.
+resampled points per cycle (if plstn or dtw_ta).
+w− , w+ samples around peak.
+sinc | cubic.
+# harmonics.
+# low-quefrency coeffs.
+DTW Sakoe–Chiba band (as fraction of M ).
+path to canonical z(t).
+none | rms | peak.
+robust averaging on/off.
+for trimmed means (e.g., 0.1).
+deterministic tie-breaks and sampling.
+
+Notes.
+• Period/phase estimates may be re-used across adapters to save compute.
+• When signal is multi-channel, apply adapters per channel or on a fused channel (e.g.,
+principal component), then concatenate.
+• Store diagnostics with each xF to enable downstream quality-aware ML (e.g., weighting
+by Jeff ).
+
+12
+
+Second-Layer Transform Adapters
+
+In addition to the cycle-synchronous adapters (A–F), we define a second layer of classical
+transform-based adapters. These operate directly on a fixed-length time series (either raw or
+first-layer adapted) to produce a fixed-length vector in RL . Each transform is well-established
+in acoustic signal processing and designed to be invariant to global time shifts.
+Notation (additive). Let Ms denote the input time-sample length provided to any secondlayer transform; for MFCC we retain CMFCC coefficients (typically 12–13).
+
+8
+
+12.1
+
+Adapter G: Fourier Transform Spectrum (FTS)
+
+Idea: Represent the signal by its frequency content. For a time series vn , n = 0, . . . , M − 1,
+the discrete Fourier transform (DFT) is
+X(k) =
+
+M
+−1
+X
+
+vn e−i2πkn/M ,
+
+k = 0, . . . , M − 1.
+
+n=0
+
+We take the magnitude spectrum |X(k)| as features. Shift invariance:
+A circular shift adds
+
+
+only a phase factor, leaving |X(k)| unchanged. Output: xF = |X(0)|, . . . , |X(M/2)| ∈
+RM/2+1 for real signals. Pros: Captures full spectral content, widely used in acoustics. Cons:
+High dimensionality; assumes stationarity over the segment. Reference: [3].
+
+12.2
+
+Adapter H: Hilbert Transform Envelope (HTE)
+
+Idea: Form the analytic signal a(t) = v(t) + iH{v(t)} using the Hilbert transform H{v}, and
+extract the amplitude envelope
+e(t) = |a(t)|,
+
+ϕ(t) = arg(a(t)).
+
+We use sampled e(t) or its summary statistics as the feature vector. Shift invariance: The
+envelope is insensitive to carrier phase and global shifts. Output: xF = [e0 , . . . , eM −1 ] or
+reduced summary. Pros: Captures amplitude modulation patterns critical in acoustics. Cons:
+Loses fine timing; may need subband envelopes. Reference: [7].
+Shift-invariance enforcement (additive). Either (i) circularly rotate e so that arg maxn en
+is at a fixed index (e.g., 0) before sampling, or (ii) compute the DCT of log(e) and keep its first
+Qe coefficients as the feature. Both produce fixed-length, shift-invariant vectors.
+
+12.3
+
+Adapter I: Wavelet Coefficient Vector (WCV)
+
+Idea: Apply the discrete wavelet transform (DWT) to obtain approximation coefficients AJ and
+detail coefficients Dj across scales j = 1, . . . , J. Collect either the raw coefficients or subband
+energies:
+X
+Ej =
+|Dj [n]|2 ,
+xF = [E1 , . . . , EJ , ∥AJ ∥22 ].
+n
+
+Shift invariance: Standard decimated DWT is shift-variant; using stationary wavelet transform
+(SWT) or aggregated energies yields approximate invariance. Output: xF ∈ RJ+1 . Pros:
+Multi-resolution time-frequency analysis; robust to nonstationarity. Cons: Choice of wavelet
+family/levels impacts results. Reference: [8].
+Shift-invariance note (additive). We use stationary (undecimated) wavelets or subbandenergy pooling to achieve approximate shift invariance.
+
+12.4
+
+Adapter J: Mel-Frequency Cepstral Coefficients (MFCC)
+
+Idea: Compute log-energy in mel-spaced frequency bands and apply discrete cosine transform
+(DCT). For B mel filters:
+1. Compute band energies Ek , k = 1..B.
+2. Yk = ln Ek .
+3. Apply DCT: cm =
+
+PB
+
+k=1 Yk cos
+
+B (k − 0.5) , m = 1..M .
+
+ πm
+
+
+
+Shift invariance: Based on spectrum magnitude only, hence invariant to global shifts. Output:
+xF = [c1 , . . . , cM ] ∈ RM . Pros: Compact, perceptually motivated, proven in speech/audio.
+Cons: Discards pitch and fine harmonic detail. Reference: [9].
+9
+
+References
+References
+[1] S. Braun, The Extraction of Periodic Waveforms by Time Domain Averaging, Acustica
+32(2), 69–77 (1975).
+[2] P. D. McFadden, Interpolation techniques for time domain averaging of gear vibration,
+Mechanical Systems and Signal Processing 3(1), 87–97 (1989).
+[3] A. V. Oppenheim and R. W. Schafer, Discrete-Time Signal Processing, Prentice Hall (1989).
+[4] A. M. Noll, Cepstrum pitch determination, J. Acoust. Soc. Am. 41(2), 293–309 (1967).
+[5] H. Sakoe and S. Chiba, Dynamic programming algorithm optimization for spoken word
+recognition, IEEE Trans. Acoust. Speech Signal Process. 26(1), 43–49 (1978).
+[6] G. L. Turin, An introduction to matched filters, IRE Trans. Information Theory 6(3), 311–
+329 (1960).
+[7] S. O. Sadjadi and J. H. L. Hansen, Hilbert envelope based features for robust speaker identification under reverberant mismatched conditions, Proc. IEEE ICASSP, 5448–5451 (2011).
+[8] G. Tzanetakis, G. Essl, and P. Cook, Audio analysis using the discrete wavelet transform,
+Proc. WSES Int. Conf. Acoustics & Music Theory & Applications, Skiathos, Greece (2001).
+[9] S. B. Davis and P. Mermelstein, Comparison of parametric representations for monosyllabic word recognition in continuously spoken sentences, IEEE Trans. Acoust. Speech Signal
+Process. 28(4), 357–366 (1980).
+
+10
+
+


### PR DESCRIPTION
## Summary
- document theory, equations, and references for all adapters
- link adapter YAML and tests to respective README files
- add plan and theory text sources for citation

## Testing
- `pre-commit run --files plan.txt theory.txt` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d8b74888322855199f5437f0118