### PR TITLE
Add basic documentation and MkDocs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.venv/
+site/

--- a/docs/adapters/cec.md
+++ b/docs/adapters/cec.md
@@ -1,0 +1,13 @@
+# CEC Adapter
+
+The Cepstral Envelope Coefficients (CEC) adapter is a first-layer method that captures the spectral envelope of a periodic signal using low-quefrency cepstral coefficients [Plan].
+
+## Algorithm
+1. Compute the log-magnitude spectrum of the waveform and take its inverse Fourier transform to obtain the real cepstrum $C(q)$.
+2. Collect the first $Q$ low-quefrency coefficients $c_q$ as the feature vector $x_F=[c_1,\ldots,c_Q]$.
+3. Because coefficients depend only on the magnitude spectrum, the representation is shift-invariant and robust to noise [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- A. M. Noll, "Cepstrum pitch determination," *J. Acoust. Soc. Am.* 41(2), 293–309 (1967).

--- a/docs/adapters/dtw_ta.md
+++ b/docs/adapters/dtw_ta.md
@@ -1,0 +1,15 @@
+# DTW-TA Adapter
+
+The Dynamic Time Warping Template Average (DTW-TA) adapter aligns each detected cycle of the waveform to a reference template using constrained DTW and averages the aligned cycles. It is a first-layer cycle-synchronous mapping [Plan].
+
+## Algorithm
+1. Build an initial template from a few cycles or another adapter output.
+2. Align each cycle to the template via constrained DTW (e.g., Sakoe–Chiba band) and resample to a common length $M$.
+3. Robust-average the aligned cycles to produce $x_F \in \mathbb{R}^M$.
+
+This procedure handles cycle length drift and shape variability while preserving shift invariance through alignment [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- H. Sakoe and S. Chiba, "Dynamic programming algorithm optimization for spoken word recognition," *IEEE Trans. Acoust. Speech Signal Process.* 26(1), 43–49 (1978).

--- a/docs/adapters/fts.md
+++ b/docs/adapters/fts.md
@@ -1,0 +1,13 @@
+# FTS Adapter
+
+The Fourier Transform Spectrum (FTS) adapter belongs to the repository's second layer of transform-based mappings, providing a shift-invariant magnitude spectrum representation [Plan].
+
+## Algorithm
+Given a time series $v_n$, compute the discrete Fourier transform
+$$X(k)=\sum_{n=0}^{M-1} v_n e^{-i2\pi kn/M},\quad k=0,\ldots,M-1.$$
+The feature vector consists of the magnitudes $|X(k)|$ (typically the first $M/2+1$ values for real signals). A circular time shift affects only phase, leaving magnitudes unchanged [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- A. V. Oppenheim and R. W. Schafer, *Discrete-Time Signal Processing*, Prentice Hall (1989).

--- a/docs/adapters/hmv.md
+++ b/docs/adapters/hmv.md
@@ -1,0 +1,16 @@
+# HMV Adapter
+
+The Harmonic Magnitude Vector (HMV) adapter is a first-layer cycle-synchronous method that summarizes a signal by the magnitudes of its first $H$ harmonics of the fundamental frequency [Plan].
+
+## Algorithm
+1. Estimate $f_0$ and compute
+   $$X(k)=\sum_n v_{F,n} e^{-i2\pi k f_0 t_{F,n}},\quad k=1,\ldots,H$$
+   where $v_{F,n}$ are samples of the waveform.
+2. Form the feature vector $x_F=[|X(1)|,\ldots,|X(H)|]$.
+
+Magnitudes remove phase, yielding shift invariance [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- A. V. Oppenheim and R. W. Schafer, *Discrete-Time Signal Processing*, Prentice Hall (1989).

--- a/docs/adapters/hte.md
+++ b/docs/adapters/hte.md
@@ -1,0 +1,14 @@
+# HTE Adapter
+
+The Hilbert Transform Envelope (HTE) adapter computes the analytic signal and extracts its amplitude envelope, yielding a shift-invariant representation of modulation patterns. It is part of the second-layer transform adapters [Plan].
+
+## Algorithm
+1. Form the analytic signal $a(t)=v(t)+i\,\mathcal{H}\{v(t)\}$ using the Hilbert transform $\mathcal{H}\{\cdot\}$.
+2. Take the envelope $e(t)=|a(t)|$ and optionally rotate or summarize it to obtain a fixed-length vector $x_F$.
+
+Because the envelope discards the carrier phase, it is insensitive to global time shifts [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- S. O. Sadjadi and J. H. L. Hansen, "Hilbert envelope based features for robust speaker identification under reverberant mismatched conditions," in *Proc. IEEE ICASSP*, 5448–5451 (2011).

--- a/docs/adapters/mfcc.md
+++ b/docs/adapters/mfcc.md
@@ -1,0 +1,16 @@
+# MFCC Adapter
+
+The Mel-Frequency Cepstral Coefficients (MFCC) adapter computes log-energy in mel-spaced frequency bands followed by a discrete cosine transform, producing a compact, shift-invariant spectral envelope. It is part of the second-layer transform adapters [Plan].
+
+## Algorithm
+1. Filter the magnitude spectrum into $B$ mel bands and compute energies $E_k$.
+2. Take logarithms $Y_k = \ln E_k$ and apply the discrete cosine transform
+   $$c_m = \sum_{k=1}^{B} Y_k \cos\left[\frac{\pi m}{B}(k-0.5)\right],\quad m=1,\ldots,M.$$
+3. Use the first $M$ coefficients $c_m$ as the feature vector $x_F$.
+
+Because only spectral magnitudes are used, the features are invariant to global shifts [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- S. B. Davis and P. Mermelstein, "Comparison of parametric representations for monosyllabic word recognition in continuously spoken sentences," *IEEE Trans. Acoust. Speech Signal Process.* 28(4), 357–366 (1980).

--- a/docs/adapters/mtp.md
+++ b/docs/adapters/mtp.md
@@ -1,0 +1,16 @@
+# MTP Adapter
+
+The Matched-Template Projection (MTP) adapter projects the waveform onto a known canonical template and reports the best-fit amplitude or coefficients. It is included in the first layer of cycle-synchronous mappings [Plan].
+
+## Algorithm
+1. Assume a reference pattern $z(t)$ shared across files.
+2. Estimate amplitude $a$ and shift $\tau$ by solving
+   $$ (\hat a, \hat\tau) = \arg\min_{a,\tau} \sum_n \left(v_{F,n} - a\, z(t_{F,n}-\tau)\right)^2 $$
+3. Use $\hat a$ or projection coefficients $\langle v_F, z_k \rangle$ as features $x_F$.
+
+Encoding only amplitudes yields shift-invariant, compact descriptors when the template is accurate [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- G. L. Turin, "An introduction to matched filters," *IRE Trans. Information Theory* 6(3), 311–329 (1960).

--- a/docs/adapters/pb_csa.md
+++ b/docs/adapters/pb_csa.md
@@ -1,0 +1,16 @@
+# PB-CSA Adapter
+
+The Phase-Bin Cycle-Synchronous Averaging (PB-CSA) adapter is a first-layer, cycle-synchronous mapping that folds each waveform by phase and averages across cycles to form a fixed-length vector [Plan].
+
+## Algorithm
+1. Estimate the fundamental period $T_0$ and compute sample phases
+   $\theta_n = 2\pi (t_{F,n} \bmod T_0)/T_0$ [Theory].
+2. Partition the phase domain into $K$ bins $\Theta_k$ and aggregate samples in each bin using a robust statistic such as the mean or median [Theory].
+3. Circularly shift the resulting vector so a reference phase is centered, ensuring approximate shift invariance [Theory].
+
+The output is $x_F \in \mathbb{R}^K$, where $K$ is the number of phase bins.
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- S. Braun, "The Extraction of Periodic Waveforms by Time Domain Averaging," *Acustica* 32(2), 69–77 (1975).

--- a/docs/adapters/plstn.md
+++ b/docs/adapters/plstn.md
@@ -1,0 +1,13 @@
+# PLSTN Adapter
+
+The Peak-Locked Segmentation & Time Normalization (PLSTN) adapter is part of the first layer of cycle-synchronous, shift-invariant mappings [Plan]. It centers windows on detected peaks, normalizes each cycle to a common length, and aggregates them.
+
+## Algorithm
+1. Detect peak indices $\{n_j\}$ with a refractory period near $T_0$.
+2. For each cycle window $W_j=[n_j-w_-, n_j+w_+]$, resample to $M$ points using bandlimited or cubic interpolation.
+3. Robust-average the normalized cycles to obtain $x_F \in \mathbb{R}^M$.
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- P. D. McFadden, "Interpolation techniques for time domain averaging of gear vibration," *Mechanical Systems and Signal Processing* 3(1), 87–97 (1989).

--- a/docs/adapters/wcv.md
+++ b/docs/adapters/wcv.md
@@ -1,0 +1,15 @@
+# WCV Adapter
+
+The Wavelet Coefficient Vector (WCV) adapter summarizes energy across wavelet scales and is part of the second-layer transform adapters [Plan].
+
+## Algorithm
+1. Apply a discrete wavelet transform to obtain approximation coefficients $A_J$ and detail coefficients $D_j$ for scales $j=1,\ldots,J$.
+2. Compute subband energies $E_j = \sum_n |D_j[n]|^2$ and optionally include $\|A_J\|_2^2$.
+3. Form the feature vector $x_F=[E_1,\ldots,E_J,\|A_J\|_2^2]$.
+
+Using stationary or energy-pooled coefficients provides approximate shift invariance [Theory].
+
+## References
+- **Plan:** *Modular Python Repository Architecture for Pressure–Oscilloscope Dataset Processing, Alignment, Adapters, and Visualization*.
+- **Theory:** *Raw Dataset Specification: Pressure & Oscilloscope Streams with File-Level Midpoint Alignment and Configurable Uncertainty*.
+- G. Tzanetakis, G. Essl, and P. Cook, "Audio analysis using the discrete wavelet transform," in *Proc. WSES Int. Conf. Acoustics & Music Theory & Applications*, Skiathos, Greece (2001).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,13 @@
+# Architecture
+
+Echpressure processes two unsynchronized data streams: a pressure stream (P-stream) providing timestamps and voltage triples, and an oscilloscope stream (O-stream) containing per-file waveforms sampled at a fixed interval. Each O-stream file is assigned a scalar pressure label by aligning its midpoint time to the nearest P-stream timestamp, with uncertainty estimated from the local pressure derivative.
+
+## Pipeline
+1. **Ingestion & Indexing** – Resolve dataset paths, parse file and record metadata, and build in-memory tables for fast lookup.
+2. **Calibration & Mapping** – Convert voltages to calibrated pressure values and compute midpoint alignment, keeping track of error bounds.
+3. **Adapters Layer 1** – Cycle-synchronous mappings such as PB-CSA, PLSTN, HMV, CEC, DTW-TA and MTP transform waveforms into fixed-length, shift-invariant representations.
+4. **Adapters Layer 2** – Transforms applied to mapped cycles including Fourier spectrum, Hilbert-envelope, wavelet energies and MFCC features.
+5. **Visualization** – Utilities to inspect raw, mapped and transformed data.
+6. **Export** – On-demand routines generate NumPy-first datasets ready for machine-learning frameworks.
+
+Hydra-driven configuration keeps the system modular while outputs remain framework-agnostic for future integration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: Echpressure
+nav:
+  - Architecture: architecture.md
+  - Adapters:
+      - CEC: adapters/cec.md
+      - DTW-TA: adapters/dtw_ta.md
+      - FTS: adapters/fts.md
+      - HMV: adapters/hmv.md
+      - HTE: adapters/hte.md
+      - MFCC: adapters/mfcc.md
+      - MTP: adapters/mtp.md
+      - PB-CSA: adapters/pb_csa.md
+      - PLSTN: adapters/plstn.md
+      - WCV: adapters/wcv.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "echpressure2"
 version = "0.0.0"
 
+[project.optional-dependencies]
+docs = ["mkdocs"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"


### PR DESCRIPTION
## Summary
- Document overall system architecture and adapter algorithms in new docs directory
- Configure MkDocs site with navigation for architecture and adapter pages
- Add optional docs dependency for building documentation

## Testing
- `.venv/bin/mkdocs build`
- `.venv/bin/python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae913d09108322b6dfabd3586042a4