### PR TITLE
Align streams using file-level midpoint

### DIFF
--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -21,9 +21,9 @@ def make_pstream(times):
 def test_basic_alignment():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
     pstream = make_pstream([5.0, 15.0, 25.0])
-    result = align_streams(ostream, pstream, tie_breaker="earliest", O_max=1.0, W=3, kappa=1.0)
-    np.testing.assert_array_equal(result.mapping, [0, 1])
-    np.testing.assert_allclose(result.E_align, [0.0, 0.0])
+    result = align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=3, kappa=1.0)
+    assert result.mapping == 0
+    np.testing.assert_allclose(result.E_align, 5.0)
 
 
 def test_O_max_enforcement():
@@ -37,23 +37,23 @@ def test_tie_break_behaviour():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0]), channels=np.zeros((0, 0)), meta={})
     pstream = make_pstream([0.0, 10.0, 20.0])
     left = align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=3, kappa=1.0)
-    assert left.mapping.tolist() == [0]
+    assert left.mapping == 0
     right = align_streams(ostream, pstream, tie_breaker="latest", O_max=10.0, W=3, kappa=1.0)
-    assert right.mapping.tolist() == [1]
+    assert right.mapping == 1
 
 
 def test_alignment_with_settings():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
-    pstream = make_pstream([5.0, 15.0, 25.0])
+    pstream = make_pstream([10.0, 20.0, 30.0])
     settings = Settings(tie_breaker="earliest", O_max=1.0, W=3, kappa=1.0)
     result = align_streams(ostream, pstream, settings=settings)
-    np.testing.assert_array_equal(result.mapping, [0, 1])
+    assert result.mapping == 0
 
 
 def test_derivative_and_uncertainty():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0, 20.0]), channels=np.zeros((0, 0)), meta={})
-    pstream = make_pstream([6.0, 16.0, 26.0])
+    pstream = make_pstream([9.0, 19.0, 29.0])
     result = align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=3, kappa=0.5)
-    np.testing.assert_allclose(result.diagnostics["dp_dt"], [1.0, 1.0], atol=1e-6)
-    np.testing.assert_allclose(result.diagnostics["delta_p"], [0.5, 0.5], atol=1e-6)
+    np.testing.assert_allclose(result.diagnostics["dp_dt"], 1.0, atol=1e-6)
+    np.testing.assert_allclose(result.diagnostics["delta_p"], 0.5, atol=1e-6)
 


### PR DESCRIPTION
## Summary
- compute a single file midpoint and align it to the nearest P-stream timestamp
- store scalar mapping/alignment values and propagate them through diagnostics
- update tests for file-level alignment and derivative uncertainty

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af3b04435c8322a7dcbf9f9ee4ba57