### PR TITLE
Add configurable E_align rejection policy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,8 @@
 
 Echpressure processes two unsynchronized data streams: a pressure stream (P-stream) providing timestamps and voltage triples, and an oscilloscope stream (O-stream) containing per-file waveforms sampled at a fixed interval. Each O-stream file is assigned a scalar pressure label by aligning its midpoint time to the nearest P-stream timestamp, with uncertainty estimated from the local pressure derivative.
 
+Alignment enforces a maximum allowable error ``O_max``. If the midpoint lies farther than this threshold from all P-stream timestamps, the file is rejected by default and marked in diagnostics. Setting ``reject_if_Ealign_gt_Omax=False`` retains the mapping but records the offending indices under ``E_align_violations``.
+
 ## Pipeline
 1. **Ingestion & Indexing** – Resolve dataset paths, parse file and record metadata, and build in-memory tables for fast lookup.
 2. **Calibration & Mapping** – Convert voltages to calibrated pressure values and compute midpoint alignment, keeping track of error bounds.

--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -30,6 +30,7 @@ class Settings:
     tie_breaker: str = "earliest"
     W: int = 5
     kappa: float = 1.0
+    reject_if_Ealign_gt_Omax: bool = True
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -43,6 +44,10 @@ class Settings:
             "tie_breaker": ("ECHOPRESS_TIE_BREAKER", str),
             "W": ("ECHOPRESS_W", int),
             "kappa": ("ECHOPRESS_KAPPA", float),
+            "reject_if_Ealign_gt_Omax": (
+                "ECHOPRESS_REJECT_IF_EALIGN_GT_OMAX",
+                lambda v: v.lower() in {"1", "true", "yes"},
+            ),
         }
         data: Dict[str, Any] = {}
         for field, (env, conv) in mapping.items():

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -29,8 +29,28 @@ def test_basic_alignment():
 def test_O_max_enforcement():
     ostream = OStream(session_id="s", timestamps=np.array([0.0, 10.0]), channels=np.zeros((0, 0)), meta={})
     pstream = make_pstream([100.0, 110.0, 120.0])
-    with pytest.raises(ValueError):
-        align_streams(ostream, pstream, tie_breaker="earliest", O_max=10.0, W=3, kappa=1.0)
+    result = align_streams(
+        ostream,
+        pstream,
+        tie_breaker="earliest",
+        O_max=10.0,
+        W=3,
+        kappa=1.0,
+    )
+    assert result.mapping == -1
+    assert result.diagnostics.get("rejected") is True
+
+    result2 = align_streams(
+        ostream,
+        pstream,
+        tie_breaker="earliest",
+        O_max=10.0,
+        W=3,
+        kappa=1.0,
+        reject_if_Ealign_gt_Omax=False,
+    )
+    assert result2.mapping == 0
+    assert result2.diagnostics.get("E_align_violations") == [0]
 
 
 def test_tie_break_behaviour():


### PR DESCRIPTION
## Summary
- allow configuring E_align > O_max behaviour via new `reject_if_Ealign_gt_Omax` setting
- track alignment threshold violations and optionally reject or record them
- document alignment rejection policy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af405ae28883229ab6e13538c8876d