### PR TITLE
Simplify pressure map keys to file level

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Echpressure processes two unsynchronized data streams: a pressure stream (P-stream) providing timestamps and voltage triples, and an oscilloscope stream (O-stream) containing per-file waveforms sampled at a fixed interval. Each O-stream file is assigned a scalar pressure label by aligning its midpoint time to the nearest P-stream timestamp, with uncertainty estimated from the local pressure derivative.
+Echpressure processes two unsynchronized data streams: a pressure stream (P-stream) providing timestamps and voltage triples, and an oscilloscope stream (O-stream) containing per-file waveforms sampled at a fixed interval. Each O-stream file is assigned a single scalar pressure label by aligning its midpoint time to the nearest P-stream timestamp, with uncertainty estimated from the local pressure derivative.
 
 Alignment enforces a maximum allowable error ``O_max``. If the midpoint lies farther than this threshold from all P-stream timestamps, the file is rejected by default and marked in diagnostics. Setting ``reject_if_Ealign_gt_Omax=False`` retains the mapping but records the offending indices under ``E_align_violations``.
 

--- a/tests/test_file2pressure_map.py
+++ b/tests/test_file2pressure_map.py
@@ -1,0 +1,23 @@
+import pytest
+
+from echopress.core.tables import Signals, OscFiles, File2PressureMap, export_tables
+
+
+def test_single_pressure_label_per_file():
+    signals = Signals()
+    signals.add("s", "f", 0, 1.0)
+    signals.add("s", "f", 1, 2.0)
+
+    osc = OscFiles()
+    osc.add("s", "f", 0, "a")
+    osc.add("s", "f", 1, "b")
+
+    fmap = File2PressureMap()
+    fmap.add("s", "f", "P")
+
+    tall = export_tables(signals, osc, fmap, tall=True)
+    labels = {row["idx"]: row["pressure_label"] for row in tall}
+    assert labels == {0: "P", 1: "P"}
+
+    with pytest.raises(KeyError):
+        fmap.add("s", "f", "Q")


### PR DESCRIPTION
## Summary
- map pressure labels by `(sid, file_stamp)` instead of `(sid, file_stamp, idx)`
- update table export and add regression test for per-file pressure labels
- clarify docs that each file carries a single pressure label

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af418ca3fc832298406ea3fee2fd08