### PR TITLE
Propagate alignment error to file mapping rows

### DIFF
--- a/tests/test_file2pressure_map.py
+++ b/tests/test_file2pressure_map.py
@@ -13,11 +13,13 @@ def test_single_pressure_value_per_file():
     osc.add("s", "f", 1, "b")
 
     fmap = File2PressureMap()
-    fmap.add("s", "f", 100.0)
+    fmap.add("s", "f", 100.0, alignment_error=0.5)
 
     tall = export_tables(signals, osc, fmap, tall=True)
     labels = {row["idx"]: row["pressure_value"] for row in tall}
     assert labels == {0: 100.0, 1: 100.0}
+    aligns = {row["idx"]: row["alignment_error"] for row in tall}
+    assert aligns == {0: 0.5, 1: 0.5}
 
     with pytest.raises(KeyError):
         fmap.add("s", "f", 101.0)


### PR DESCRIPTION
## Summary
- track `alignment_error` on each file->pressure mapping row
- drop per-sample `alignment_error` from `SignalRow`
- export consolidated rows with file-level `alignment_error`
- extend tests to cover new alignment error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af495eb3288322b0423652a22365b3