### PR TITLE
feat: add indexing and adapt commands

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -15,11 +15,48 @@ from .core.calibration import apply_calibration
 from .core.mapping import align_streams
 from .core.tables import File2PressureMap, OscFiles, Signals, export_tables
 from .config import Settings
-from .ingest import load_ostream, read_pstream
+from .ingest import DatasetIndexer, load_ostream, read_pstream
 import json
 
 
 app = typer.Typer(help="Utilities for the echopress project")
+
+
+@app.command()
+def index(
+    ctx: typer.Context,
+    cache: Optional[str] = typer.Option(None, "--cache", "-c"),
+) -> None:
+    """Scan the dataset directory and cache file paths.
+
+    The resulting index is a JSON file containing mappings of session
+    identifiers to available O-stream and P-stream files.  It can be reused
+    by other commands to avoid repeatedly walking the dataset tree.
+    """
+
+    cfg: DictConfig = ctx.obj
+    root_cfg = getattr(cfg.dataset, "root", None)
+    root_path: Path
+    if isinstance(root_cfg, str):
+        root_path = Path(root_cfg)
+    else:
+        # ``root`` may be a mapping with ``ostream``/``pstream`` entries; use
+        # the O-stream root as the base directory since most datasets place
+        # all files under a common tree.
+        root_path = Path(getattr(root_cfg, "ostream", "."))
+
+    indexer = DatasetIndexer(root_path)
+    data = {
+        "pstreams": {sid: [str(p) for p in paths] for sid, paths in indexer.pstreams.items()},
+        "ostreams": {sid: [str(o) for o in paths] for sid, paths in indexer.ostreams.items()},
+    }
+
+    cache_path = Path(cache) if cache else root_path / "index.json"
+    with open(cache_path, "w", encoding="utf8") as fh:
+        json.dump(data, fh)
+    typer.echo(
+        f"Indexed dataset at {root_path}, cached {len(indexer.sessions())} sessions to {cache_path}"
+    )
 
 
 @app.command()
@@ -97,9 +134,12 @@ def align(
         signals.add(sid, file_stamp, idx, float(value))
         osc_files.add(sid, file_stamp, idx, str(file_path))
 
+    pressure_value = None
     if result.mapping >= 0:
         pressure_value = pstream[result.mapping].pressure
         fmap.add(sid, file_stamp, pressure_value, alignment_error=result.E_align)
+
+    delta_p = result.diagnostics.get("delta_p")
 
     if export:
         tables = export_tables(signals, osc_files, fmap, tall=True)
@@ -110,27 +150,96 @@ def align(
         typer.echo(
             f"Signals: {len(signals)}, OscFiles: {len(osc_files)}, File2PressureMap: {len(fmap)}"
         )
-        typer.echo(
-            f"Alignment index: {result.mapping}, E_align={result.E_align:.6f}"
-        )
+        if pressure_value is not None and delta_p is not None:
+            typer.echo(
+                f"Alignment index: {result.mapping}, E_align={result.E_align:.6f}, ΔP={delta_p:.6f}"
+            )
+        else:
+            typer.echo(
+                f"Alignment index: {result.mapping}, E_align={result.E_align:.6f}"
+            )
 
 
 @app.command()
-def adapter(ctx: typer.Context, signal: str, output: str) -> None:
-    """Run an adapter on ``signal`` and save its first output array."""
+def adapt(
+    ctx: typer.Context,
+    adapter: Optional[str] = typer.Option(None, "--adapter", "-a"),
+    pr_min: Optional[float] = typer.Option(None, "--pr-min"),
+    pr_max: Optional[float] = typer.Option(None, "--pr-max"),
+    n: int = typer.Option(1, "--n"),
+    export: Optional[str] = typer.Option(None, "--export", "-o"),
+) -> None:
+    """Apply adapters to files sampled from the dataset.
+
+    The command searches the dataset root for available O- and P-stream pairs,
+    filters them by the pressure value obtained from alignment and then applies
+    the selected adapter.  ``n`` controls how many files are processed (using
+    deterministic ordering rather than random sampling to keep behaviour
+    predictable in tests).
+    """
 
     cfg: DictConfig = ctx.obj
-    data = np.load(signal)
-    adapter_obj = get_adapter(cfg.adapter.name)
+
+    adapter_name = adapter or cfg.adapter.name
+    adapter_obj = get_adapter(adapter_name)
     fs = cfg.adapter.period_est.fs
     f0 = cfg.adapter.period_est.f0
-    cycles = adapter_obj.layer1(data, fs=fs, f0=f0)
-    outputs = adapter_obj.layer2(cycles, fs=fs)
-    first_key = next(iter(outputs))
-    result = outputs[first_key]
-    if cfg.adapter.output_length:
-        result = result[..., : cfg.adapter.output_length]
-    np.save(output, result)
+
+    root_cfg = getattr(cfg.dataset, "root", None)
+    root_path: Path
+    if isinstance(root_cfg, str):
+        root_path = Path(root_cfg)
+    else:
+        root_path = Path(getattr(root_cfg, "ostream", "."))
+
+    indexer = DatasetIndexer(root_path)
+    processed = 0
+    for sid in indexer.sessions():
+        if processed >= n:
+            break
+        o_path = indexer.first_ostream(sid)
+        p_path = indexer.first_pstream(sid)
+        if o_path is None or p_path is None:
+            continue
+        ostream = load_ostream(o_path)
+        pstream = list(read_pstream(p_path))
+        result = align_streams(
+            ostream,
+            pstream,
+            tie_breaker=cfg.mapping.tie_breaker,
+            O_max=cfg.mapping.O_max,
+            W=cfg.mapping.W,
+            kappa=cfg.mapping.kappa,
+            reject_if_Ealign_gt_Omax=cfg.quality.reject_if_Ealign_gt_Omax,
+        )
+        if result.mapping < 0:
+            continue
+        pressure_value = pstream[result.mapping].pressure
+        if pr_min is not None and pressure_value < pr_min:
+            continue
+        if pr_max is not None and pressure_value > pr_max:
+            continue
+
+        data = np.asarray(ostream.channels)
+        if data.ndim == 2:
+            data = data[:, 0]
+        data = data.reshape(-1)
+        cycles = adapter_obj.layer1(data, fs=fs, f0=f0)
+        outputs = adapter_obj.layer2(cycles, fs=fs)
+        first_key = next(iter(outputs))
+        result_arr = outputs[first_key]
+        if cfg.adapter.output_length:
+            result_arr = result_arr[..., : cfg.adapter.output_length]
+        if export:
+            # If multiple files are processed the last one wins; this is
+            # sufficient for our simple use case.
+            np.save(export, result_arr)
+        typer.echo(
+            f"processed {o_path.name}: adapter={adapter_name} output_shape={result_arr.shape} pressure={pressure_value}"
+        )
+        processed += 1
+    if processed == 0:
+        typer.echo("No files matched the requested pressure range")
 
 
 @app.command()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,59 @@
+import json
+import numpy as np
+from typer.testing import CliRunner
+from omegaconf import OmegaConf
+
+from echopress.cli import app
+
+
+def make_cfg(tmp_path):
+    o_path = tmp_path / "s1.npz"
+    np.savez(
+        o_path,
+        session_id="s1",
+        timestamps=np.array([0.0, 1.0, 2.0]),
+        channels=np.array([1.0, 2.0, 3.0]),
+    )
+    p_path = tmp_path / "s1.pstream"
+    p_path.write_text("\n".join(["0 0 0 10", "1 0 0 11", "2 0 0 12"]))
+    cfg = OmegaConf.create(
+        {
+            "dataset": {
+                "root": {"ostream": str(tmp_path), "pstream": str(tmp_path)},
+                "ostream": str(o_path),
+                "pstream": str(p_path),
+            },
+            "mapping": {"tie_breaker": "earliest", "O_max": 2.0, "W": 5, "kappa": 1.0},
+            "quality": {"reject_if_Ealign_gt_Omax": True, "min_records_in_W": 1},
+            "calibration": {"alpha": [1, 1, 1], "beta": [0, 0, 0]},
+            "pressure": {"scalar_channel": 2},
+            "units": {"pressure": "Pa", "voltage": "V"},
+            "timestamp": {"timezone": "UTC"},
+            "adapter": {
+                "name": "cec",
+                "output_length": 0,
+                "period_est": {"fs": 1.0, "f0": 1.0},
+            },
+            "viz": {},
+        }
+    )
+    return cfg, o_path, p_path
+
+
+def test_index_align_adapt(tmp_path):
+    cfg, o_path, p_path = make_cfg(tmp_path)
+    runner = CliRunner()
+
+    cache_path = tmp_path / "index.json"
+    result = runner.invoke(app, ["index", "--cache", str(cache_path)], obj=cfg)
+    assert result.exit_code == 0
+    data = json.loads(cache_path.read_text())
+    assert "s1" in data["ostreams"]
+
+    result = runner.invoke(app, ["align"], obj=cfg)
+    assert "E_align" in result.stdout
+    assert "ΔP" in result.stdout
+
+    result = runner.invoke(app, ["adapt", "--adapter", "cec", "--n", "1"], obj=cfg)
+    assert result.exit_code == 0
+    assert "adapter=cec" in result.stdout


### PR DESCRIPTION
## Summary
- add `index` command to cache dataset file paths
- enhance `align` with ΔP metric and optional export
- replace low-level `adapter` with higher level `adapt` supporting pressure-based sampling
- cover new CLI commands with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5286c4b48322ab29942eef6f2cbc