### PR TITLE
Index voltprsr CSV files as pstreams

### DIFF
--- a/src/echopress/ingest/indexer.py
+++ b/src/echopress/ingest/indexer.py
@@ -24,6 +24,11 @@ def _session_id(path: Path) -> str:
     return path.stem
 
 
+def _is_pstream_csv(path: Path) -> bool:
+    """Return ``True`` if ``path`` is a P-stream CSV produced by voltprsr."""
+    return path.suffix.lower() == ".csv" and "voltprsr" in path.stem.lower()
+
+
 @dataclass
 class DatasetIndexer:
     """Index of dataset files on disk."""
@@ -45,8 +50,11 @@ class DatasetIndexer:
         for path in self.root.rglob("*"):
             if not path.is_file():
                 continue
-            suffix = path.suffix.lower()
             sid = _session_id(path)
+            if _is_pstream_csv(path):
+                self.pstreams.setdefault(sid, []).append(path)
+                continue
+            suffix = path.suffix.lower()
             if suffix in PSTREAM_EXTENSIONS:
                 self.pstreams.setdefault(sid, []).append(path)
             elif suffix in OSTREAM_EXTENSIONS:

--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -1,0 +1,10 @@
+from echopress.ingest import DatasetIndexer
+
+
+def test_dataset_indexer_picks_up_voltprsr_csv(tmp_path):
+    csv_path = tmp_path / "voltprsr001.csv"
+    csv_path.write_text("timestamp\n0.0\n")
+    indexer = DatasetIndexer(tmp_path)
+    assert "voltprsr001" in indexer.pstreams
+    assert csv_path in indexer.pstreams["voltprsr001"]
+    assert "voltprsr001" not in indexer.ostreams


### PR DESCRIPTION
## Summary
- treat voltprsr-generated CSV files as P-streams
- ensure scan() identifies voltprsr CSVs as pstreams
- test indexing of voltprsr001.csv

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af83a71ef88322b7a087abef9aa521