### PR TITLE
feat: add adapt CLI output saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ python -m echopress.cli index
 # Align O-stream files to the P-stream and compute uncertainty bounds
 python -m echopress.cli align
 
-# Run an adapter and save features
-python -m echopress.cli adapt --adapter cec signal.npy -o features.npy
+# Run an adapter on files within a pressure range and save features
+python -m echopress.cli adapt --adapter cec --pr-min 80 --pr-max 120 --n 5 --output features.npy
 ```
 
 Existing commands such as `ingest`, `calibrate` and `viz` remain available.

--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -168,6 +168,7 @@ def adapt(
     pr_min: Optional[float] = typer.Option(None, "--pr-min"),
     pr_max: Optional[float] = typer.Option(None, "--pr-max"),
     n: Optional[int] = typer.Option(None, "--n"),
+    output: Optional[str] = typer.Option(None, "--output", "-o"),
     plot: Optional[bool] = typer.Option(None, "--plot/--no-plot"),
 ) -> Optional[List[np.ndarray]]:
     """Apply adapters to files sampled from the dataset.
@@ -177,8 +178,10 @@ def adapt(
     A random subset of ``n`` files is processed using the adapter selected by
     ``--adapter``.  When ``--plot`` is provided the raw signal and adapter
     outputs are visualised using helper functions from :mod:`viz.plot_adapter`.
-    The processed NumPy arrays are returned to the caller when executed from
-    Python, otherwise a summary is printed.
+    When ``--output`` is supplied the resulting feature vectors are written to
+    a NumPy file at the given path.  The processed NumPy arrays are returned to
+    the caller when executed from Python and ``--output`` is omitted, otherwise
+    a summary is printed.
     """
 
     cfg: DictConfig = ctx.obj
@@ -258,6 +261,12 @@ def adapt(
                 _plot_adapter(data, result_arr)
             except Exception:  # pragma: no cover - graceful fallback
                 typer.echo("Plotting unavailable")
+
+    if output:
+        out_path = Path(output)
+        np.save(out_path, np.stack(outputs))
+        typer.echo(f"saved {len(outputs)} feature arrays to {out_path}")
+        return None
 
     return outputs
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -62,6 +62,14 @@ def test_index_align_adapt(tmp_path):
     data = json.loads(align_path.read_text())
     assert any("pressure_value" in row for row in data)
 
-    result = runner.invoke(app, ["adapt", "--adapter", "cec", "--n", "1"], obj=cfg)
+    out_path = tmp_path / "features.npy"
+    result = runner.invoke(
+        app,
+        ["adapt", "--adapter", "cec", "--n", "1", "--output", str(out_path)],
+        obj=cfg,
+    )
     assert result.exit_code == 0
     assert "adapter=cec" in result.stdout
+    assert out_path.exists()
+    data = np.load(out_path)
+    assert data.shape[0] == 1


### PR DESCRIPTION
## Summary
- add `--output` flag to `adapt` command to save adapter features
- document new adapt usage and pressure-range sampling
- test adapter flow with feature export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af8a564fe08322acf14741d56f77a7