### PR TITLE
Add CSV parsing to P-stream ingestion

### DIFF
--- a/tests/test_pstream_csv.py
+++ b/tests/test_pstream_csv.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timezone
+
+from echopress.ingest import read_pstream
+
+
+def test_read_pstream_csv(tmp_path):
+    data = "timestamp,pressure\n0.0,1.0\n1.0,2.0\n"
+    file = tmp_path / "sample.csv"
+    file.write_text(data)
+    records = list(read_pstream(file))
+    assert len(records) == 2
+    assert records[0].pressure == 1.0
+    assert records[0].timestamp == datetime.fromtimestamp(0.0, tz=timezone.utc)
+    assert records[0].voltages == (0.0, 0.0, 0.0)


### PR DESCRIPTION
## Summary
- handle `.csv` files in `read_pstream`
- parse CSV rows with `csv.DictReader` and convert timestamps
- test CSV ingestion path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8d065c2c8322a765471a53daad96