### PR TITLE
Handle missing voltages in P-stream records

### DIFF
--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -11,8 +11,8 @@ def make_pstream(times):
     return [
         PStreamRecord(
             datetime.fromtimestamp(t, tz=timezone.utc),
-            (0.0, 0.0, t),
             t,
+            voltages=(0.0, 0.0, t),
         )
         for t in times
     ]

--- a/tests/test_pstream_csv.py
+++ b/tests/test_pstream_csv.py
@@ -11,4 +11,4 @@ def test_read_pstream_csv(tmp_path):
     assert len(records) == 2
     assert records[0].pressure == 1.0
     assert records[0].timestamp == datetime.fromtimestamp(0.0, tz=timezone.utc)
-    assert records[0].voltages == (0.0, 0.0, 0.0)
+    assert records[0].voltages is None


### PR DESCRIPTION
## Summary
- Allow `PStreamRecord` to omit voltage readings and default to `None`
- Parse lines or CSV rows lacking voltage columns by reading pressure directly
- Adjust tests for optional `voltages` field

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af93118a608322bd109b0a80173a8c