### PR TITLE
Support CSV P-stream inputs

### DIFF
--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -8,3 +8,12 @@ def test_dataset_indexer_picks_up_voltprsr_csv(tmp_path):
     assert "voltprsr001" in indexer.pstreams
     assert csv_path in indexer.pstreams["voltprsr001"]
     assert "voltprsr001" not in indexer.ostreams
+
+
+def test_dataset_indexer_picks_up_mixedcase_voltprsr_csv(tmp_path):
+    csv_path = tmp_path / "VoltPrsr001.csv"
+    csv_path.write_text("timestamp\n0.0\n")
+    indexer = DatasetIndexer(tmp_path)
+    assert "VoltPrsr001" in indexer.pstreams
+    assert csv_path in indexer.pstreams["VoltPrsr001"]
+    assert "VoltPrsr001" not in indexer.ostreams

--- a/tests/test_pstream_csv_ingest.py
+++ b/tests/test_pstream_csv_ingest.py
@@ -1,0 +1,14 @@
+from echopress.ingest import read_pstream
+
+
+def test_read_pstream_csv(tmp_path):
+    csv_path = tmp_path / "VoltPrsr001.csv"
+    csv_path.write_text("\n".join([
+        "timestamp,pressure",
+        "0.0,1.0",
+        "1.0,2.0",
+    ]))
+    records = list(read_pstream(csv_path))
+    assert [r.pressure for r in records] == [1.0, 2.0]
+    assert [r.timestamp.timestamp() for r in records] == [0.0, 1.0]
+    assert all(r.voltages is None for r in records)


### PR DESCRIPTION
## Summary
- allow `read_pstream` to ingest CSV files using `csv.DictReader`
- make PStreamRecord voltages optional and parse two-column text records
- add tests for CSV ingestion and mixed-case voltprsr filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8eefc1a483228be837c95a72c97f