### PR TITLE
Add configurable P-stream CSV patterns

### DIFF
--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -89,6 +89,9 @@ class Settings:
     units: UnitsSettings = field(default_factory=UnitsSettings)
     timestamp: TimestampSettings = field(default_factory=TimestampSettings)
     quality: QualitySettings = field(default_factory=QualitySettings)
+    pstream_csv_patterns: list[str] = field(
+        default_factory=lambda: ["voltprsr"]
+    )
 
     # ------------------------------------------------------------------
     # Helpers
@@ -125,6 +128,10 @@ class Settings:
             "timestamp.format": ("ECHOPRESS_TIMESTAMP_FORMAT", str),
             "timestamp.timezone": ("ECHOPRESS_TIMESTAMP_TIMEZONE", str),
             "timestamp.year_fallback": ("ECHOPRESS_TIMESTAMP_YEAR_FALLBACK", int),
+            "pstream_csv_patterns": (
+                "ECHOPRESS_PSTREAM_CSV_PATTERNS",
+                lambda v: [s.strip() for s in v.split(",") if s.strip()],
+            ),
         }
         for path, (env, conv) in mapping.items():
             if env in os.environ:

--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -1,4 +1,5 @@
 from echopress.ingest import DatasetIndexer
+from echopress.config import Settings
 
 
 def test_dataset_indexer_picks_up_voltprsr_csv(tmp_path):
@@ -8,3 +9,18 @@ def test_dataset_indexer_picks_up_voltprsr_csv(tmp_path):
     assert "voltprsr001" in indexer.pstreams
     assert csv_path in indexer.pstreams["voltprsr001"]
     assert "voltprsr001" not in indexer.ostreams
+
+
+def test_dataset_indexer_picks_up_multiple_patterns(tmp_path):
+    (tmp_path / "voltprsr001.csv").write_text("timestamp\n0.0\n")
+    (tmp_path / "anotherpstream.csv").write_text("timestamp\n0.0\n")
+    (tmp_path / "sessionA.csv").write_text(
+        "session_id,timestamp,ch0\nsessionA,0.0,1.0\n"
+    )
+    settings = Settings()
+    settings.pstream_csv_patterns = ["voltprsr", "anotherpstream"]
+    indexer = DatasetIndexer(tmp_path, settings=settings)
+    assert "voltprsr001" in indexer.pstreams
+    assert "anotherpstream" in indexer.pstreams
+    assert "sessionA" in indexer.ostreams
+    assert "sessionA" not in indexer.pstreams


### PR DESCRIPTION
## Summary
- allow Settings.pstream_csv_patterns to configure P-stream CSV detection
- teach DatasetIndexer to classify P-stream CSVs using configured patterns
- add regression test for multiple P-stream patterns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af973f6684832298d8f7069b740dfc