### PR TITLE
Normalize DatasetIndexer session IDs

### DIFF
--- a/src/echopress/ingest/indexer.py
+++ b/src/echopress/ingest/indexer.py
@@ -21,9 +21,10 @@ OSTREAM_EXTENSIONS = {".ostream", ".o", ".os", ".npz", ".json", ".csv"}
 def _session_id(path: Path) -> str:
     """Derive a session identifier from ``path``.
 
-    The default strategy uses the stem (basename without extensions).
+    The default strategy uses the stem (basename without extensions)
+    and normalizes it to lower case so lookups are case-insensitive.
     """
-    return path.stem
+    return path.stem.lower()
 
 
 def _is_pstream_csv(path: Path, patterns: Iterable[str]) -> bool:
@@ -73,11 +74,11 @@ class DatasetIndexer:
 
     def get_pstreams(self, session_id: str) -> List[Path]:
         """Return P-stream files for ``session_id`` (possibly empty)."""
-        return self.pstreams.get(session_id, [])
+        return self.pstreams.get(session_id.lower(), [])
 
     def get_ostreams(self, session_id: str) -> List[Path]:
         """Return O-stream files for ``session_id`` (possibly empty)."""
-        return self.ostreams.get(session_id, [])
+        return self.ostreams.get(session_id.lower(), [])
 
     def first_pstream(self, session_id: str) -> Optional[Path]:
         """Convenience method returning the first P-stream file for a session."""

--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -22,5 +22,12 @@ def test_dataset_indexer_picks_up_multiple_patterns(tmp_path):
     indexer = DatasetIndexer(tmp_path, settings=settings)
     assert "voltprsr001" in indexer.pstreams
     assert "anotherpstream" in indexer.pstreams
-    assert "sessionA" in indexer.ostreams
-    assert "sessionA" not in indexer.pstreams
+    assert "sessiona" in indexer.ostreams
+    assert "sessiona" not in indexer.pstreams
+
+
+def test_dataset_indexer_case_insensitive_lookup(tmp_path):
+    csv_path = tmp_path / "VoltPrsr001.csv"
+    csv_path.write_text("timestamp\n0.0\n")
+    indexer = DatasetIndexer(tmp_path)
+    assert indexer.get_pstreams("voltprsr001") == [csv_path]

--- a/tests/test_ostream_csv.py
+++ b/tests/test_ostream_csv.py
@@ -20,5 +20,5 @@ def test_dataset_indexer_picks_up_csv(tmp_path):
     csv_path = tmp_path / "sessionA.csv"
     csv_path.write_text("session_id,timestamp,ch0\nsessionA,0.0,1.0\n")
     indexer = DatasetIndexer(tmp_path)
-    assert "sessionA" in indexer.ostreams
-    assert csv_path in indexer.ostreams["sessionA"]
+    assert "sessiona" in indexer.ostreams
+    assert csv_path in indexer.ostreams["sessiona"]


### PR DESCRIPTION
## Summary
- ensure DatasetIndexer uses lowercase session identifiers
- normalize lookup keys in DatasetIndexer get methods
- add regression test for case-insensitive P-stream indexing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9b4f21048322b0e1565ade356d96