### PR TITLE
Strip CSV prefixes for P-stream session IDs

### DIFF
--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -6,28 +6,28 @@ def test_dataset_indexer_picks_up_voltprsr_csv(tmp_path):
     csv_path = tmp_path / "voltprsr001.csv"
     csv_path.write_text("timestamp\n0.0\n")
     indexer = DatasetIndexer(tmp_path)
-    assert "voltprsr001" in indexer.pstreams
-    assert csv_path in indexer.pstreams["voltprsr001"]
-    assert "voltprsr001" not in indexer.ostreams
+    assert "001" in indexer.pstreams
+    assert csv_path in indexer.pstreams["001"]
+    assert "001" not in indexer.ostreams
 
 
 def test_dataset_indexer_picks_up_multiple_patterns(tmp_path):
     (tmp_path / "voltprsr001.csv").write_text("timestamp\n0.0\n")
-    (tmp_path / "anotherpstream.csv").write_text("timestamp\n0.0\n")
+    (tmp_path / "anotherpstream002.csv").write_text("timestamp\n0.0\n")
     (tmp_path / "sessionA.csv").write_text(
         "session_id,timestamp,ch0\nsessionA,0.0,1.0\n"
     )
     settings = Settings()
     settings.pstream_csv_patterns = ["voltprsr", "anotherpstream"]
     indexer = DatasetIndexer(tmp_path, settings=settings)
-    assert "voltprsr001" in indexer.pstreams
-    assert "anotherpstream" in indexer.pstreams
+    assert "001" in indexer.pstreams
+    assert "002" in indexer.pstreams
     assert "sessiona" in indexer.ostreams
     assert "sessiona" not in indexer.pstreams
 
 
-def test_dataset_indexer_case_insensitive_lookup(tmp_path):
+def test_dataset_indexer_lookup_by_stripped_id(tmp_path):
     csv_path = tmp_path / "VoltPrsr001.csv"
     csv_path.write_text("timestamp\n0.0\n")
     indexer = DatasetIndexer(tmp_path)
-    assert indexer.get_pstreams("voltprsr001") == [csv_path]
+    assert indexer.get_pstreams("001") == [csv_path]


### PR DESCRIPTION
## Summary
- Strip configured prefixes from P-stream CSV stems when deriving session IDs
- Key CSV P-streams by stripped ID during dataset scan
- Update and extend P-stream CSV indexer tests for prefix stripping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9c3770fc8322881c35b2115fed43