### PR TITLE
feat: configurable P-stream CSV patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ configuration in `conf/config.yaml` composes several YAML groups under `conf/`,
 including:
 
 * `dataset` – paths to example O- and P-streams (O-streams may be `.npz`, `.json`, or `.csv`)
+* `ingest` – patterns to recognise P-stream CSV files (default `['voltprsr']`)
 * `mapping` – alignment and derivative parameters
 * `calibration` – per-channel calibration coefficients
 * `pressure` – which channel contains scalar pressure data

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,5 +1,6 @@
 defaults:
   - dataset: default
+  - ingest: default
   - mapping: default
   - calibration: default
   - pressure: default

--- a/conf/ingest/default.yaml
+++ b/conf/ingest/default.yaml
@@ -1,0 +1,5 @@
+# Patterns identifying CSV files containing P-stream data. Each entry may be
+# a simple substring or a regular expression.
+pstream_csv_patterns:
+  - voltprsr
+

--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -80,6 +80,15 @@ class QualitySettings:
 
 
 @dataclass
+class IngestSettings:
+    """Options controlling dataset ingestion."""
+
+    pstream_csv_patterns: list[str] = field(
+        default_factory=lambda: ["voltprsr"]
+    )
+
+
+@dataclass
 class Settings:
     """Container for all runtime configuration sections."""
 
@@ -89,9 +98,7 @@ class Settings:
     units: UnitsSettings = field(default_factory=UnitsSettings)
     timestamp: TimestampSettings = field(default_factory=TimestampSettings)
     quality: QualitySettings = field(default_factory=QualitySettings)
-    pstream_csv_patterns: list[str] = field(
-        default_factory=lambda: ["voltprsr"]
-    )
+    ingest: IngestSettings = field(default_factory=IngestSettings)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -128,8 +135,8 @@ class Settings:
             "timestamp.format": ("ECHOPRESS_TIMESTAMP_FORMAT", str),
             "timestamp.timezone": ("ECHOPRESS_TIMESTAMP_TIMEZONE", str),
             "timestamp.year_fallback": ("ECHOPRESS_TIMESTAMP_YEAR_FALLBACK", int),
-            "pstream_csv_patterns": (
-                "ECHOPRESS_PSTREAM_CSV_PATTERNS",
+            "ingest.pstream_csv_patterns": (
+                "ECHOPRESS_INGEST_PSTREAM_CSV_PATTERNS",
                 lambda v: [s.strip() for s in v.split(",") if s.strip()],
             ),
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,12 @@ def test_from_env(monkeypatch):
     assert s.calibration.alpha[0] == 2.5
 
 
+def test_from_env_ingest_patterns(monkeypatch):
+    monkeypatch.setenv("ECHOPRESS_INGEST_PSTREAM_CSV_PATTERNS", "foo,bar")
+    s = Settings.from_env()
+    assert s.ingest.pstream_csv_patterns == ["foo", "bar"]
+
+
 def test_load_settings_json(tmp_path):
     p = tmp_path / "cfg.json"
     p.write_text(json.dumps({"calibration": {"beta": [1.2]}, "mapping": {"W": 7}}))

--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -18,7 +18,7 @@ def test_dataset_indexer_picks_up_multiple_patterns(tmp_path):
         "session_id,timestamp,ch0\nsessionA,0.0,1.0\n"
     )
     settings = Settings()
-    settings.pstream_csv_patterns = ["voltprsr", "anotherpstream"]
+    settings.ingest.pstream_csv_patterns = ["voltprsr", "anotherpstream"]
     indexer = DatasetIndexer(tmp_path, settings=settings)
     assert "001" in indexer.pstreams
     assert "002" in indexer.pstreams
@@ -31,3 +31,14 @@ def test_dataset_indexer_lookup_by_stripped_id(tmp_path):
     csv_path.write_text("timestamp\n0.0\n")
     indexer = DatasetIndexer(tmp_path)
     assert indexer.get_pstreams("001") == [csv_path]
+
+
+def test_dataset_indexer_accepts_regex_patterns(tmp_path):
+    csv_path = tmp_path / "VoltPrsr123.csv"
+    csv_path.write_text("timestamp\n0.0\n")
+    settings = Settings()
+    settings.ingest.pstream_csv_patterns = [r"voltprsr\d+"]
+    indexer = DatasetIndexer(tmp_path, settings=settings)
+    assert "voltprsr123" in indexer.pstreams
+    assert csv_path in indexer.pstreams["voltprsr123"]
+


### PR DESCRIPTION
## Summary
- group ingestion options under Settings.ingest with `pstream_csv_patterns`
- allow `_is_pstream_csv` to accept substring or regex patterns
- document ingestion patterns and provide Hydra config

## Testing
- `pytest tests/test_indexer_pstream_csv.py tests/test_config.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'omegaconf')*

------
https://chatgpt.com/codex/tasks/task_e_68afa3b046e083228ca63eeb70b01089