### PR TITLE
Document P-stream CSV convention

### DIFF
--- a/docs/pstream.md
+++ b/docs/pstream.md
@@ -1,0 +1,25 @@
+# P-stream CSVs
+
+P-streams record pressure measurements alongside timestamps. Files are
+conventionally named `voltprsr{ID}.csv`—for example, `voltprsr001.csv`—so the
+`DatasetIndexer` can extract the identifier and catalog them. The default
+configuration searches for this prefix, though additional patterns may be
+supplied under `ingest.pstream_csv_patterns`.
+
+The simplest P-stream CSV contains two columns: `timestamp` and `pressure`.
+`read_pstream` understands this format and yields `PStreamRecord` objects. The
+function attempts to parse each `timestamp` using the configured grammar and
+falls back to interpreting the value as seconds since the Unix epoch when no
+explicit format matches.
+
+```python
+from echopress.ingest import DatasetIndexer, read_pstream
+
+# Locate files like 'voltprsr001.csv'
+indexer = DatasetIndexer("/data")
+pstream_file = indexer.first_pstream("001")
+
+# Iterate over timestamp,pressure rows
+for record in read_pstream(pstream_file):
+    print(record.timestamp, record.pressure)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Echpressure
 nav:
   - Architecture: architecture.md
+  - P-streams: pstream.md
   - Adapters:
       - CEC: adapters/cec.md
       - DTW-TA: adapters/dtw_ta.md


### PR DESCRIPTION
## Summary
- describe `voltprsr*.csv` naming and `read_pstream` parsing of `timestamp,pressure`
- add example of indexing and loading P-stream CSVs
- document P-stream CSV format in dedicated page and mkdocs navigation

## Testing
- `pytest tests/test_indexer_pstream_csv.py tests/test_indexer_read_pstream_example.py tests/test_pstream_csv.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68afa6a2f46c8322bcb63c4ff2c4df2f