### PR TITLE
Support P-stream CSV files in CLI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ utils/ & types.py  shared utilities and data types
 
 ## Usage
 
-Once the CLI exposes the full pipeline, a typical flow looks like:
+Once the CLI exposes the full pipeline, a typical flow looks like below.
+Commands accept traditional `.pstream` text files or `voltprsr*.csv`
+P-streams:
 
 ```bash
-# Build dataset indices from configured paths
+# Build dataset indices from configured paths (supports .pstream and CSV)
 python -m echopress.cli index
 
-# Align O-stream files to the P-stream and compute uncertainty bounds
+# Align O-stream files to the P-stream (.pstream or CSV) and compute uncertainty bounds
 python -m echopress.cli align
 
 # Run an adapter on files within a pressure range and save features

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -14,8 +14,8 @@ def make_cfg(tmp_path):
         timestamps=np.array([0.0, 1.0, 2.0]),
         channels=np.array([1.0, 2.0, 3.0]),
     )
-    p_path = tmp_path / "s1.pstream"
-    p_path.write_text("\n".join(["0 0 0 10", "1 0 0 11", "2 0 0 12"]))
+    p_path = tmp_path / "voltprsr001.csv"
+    p_path.write_text("timestamp,pressure\n0,10\n1,11\n2,12\n")
     align_path = tmp_path / "align.json"
     cfg = OmegaConf.create(
         {
@@ -56,6 +56,7 @@ def test_index_align_adapt(tmp_path):
     assert result.exit_code == 0
     data = json.loads(cache_path.read_text())
     assert "s1" in data["ostreams"]
+    assert "001" in data["pstreams"]
 
     result = runner.invoke(app, ["align", "--export", str(align_path)], obj=cfg)
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- use a `voltprsr*.csv` file in CLI tests to ensure indexing and alignment work with P-stream CSVs
- document that CLI commands accept `.pstream` or P-stream CSV files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afa90fe4888322a33a15f5f86d9feb