### PR TITLE
Validate CSV headers in read_pstream

### DIFF
--- a/src/echopress/ingest/pstream.py
+++ b/src/echopress/ingest/pstream.py
@@ -174,6 +174,13 @@ def read_pstream(
             tz = ZoneInfo(settings.timestamp.timezone)
             with open(p, newline="", encoding="utf8") as fh:
                 reader = csv.DictReader(fh)
+                required = {"timestamp", "pressure"}
+                if reader.fieldnames is None or not required.issubset(reader.fieldnames):
+                    found = reader.fieldnames if reader.fieldnames is not None else []
+                    raise ValueError(
+                        "CSV P-stream header must contain 'timestamp' and 'pressure' columns; "
+                        f"found {found}"
+                    )
                 for row in reader:
                     ts_val = row.get("timestamp")
                     p_val = row.get("pressure")

--- a/tests/test_pstream_csv.py
+++ b/tests/test_pstream_csv.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from echopress.ingest import read_pstream
 
 
@@ -12,3 +14,11 @@ def test_read_pstream_csv(tmp_path):
     assert records[0].pressure == 1.0
     assert records[0].timestamp == datetime.fromtimestamp(0.0, tz=timezone.utc)
     assert records[0].voltages is None
+
+
+def test_read_pstream_csv_bad_headers(tmp_path):
+    data = "time,pressure\n0.0,1.0\n"
+    file = tmp_path / "bad.csv"
+    file.write_text(data)
+    with pytest.raises(ValueError):
+        list(read_pstream(file))


### PR DESCRIPTION
## Summary
- ensure CSV P-stream files contain `timestamp` and `pressure` headers and raise a `ValueError` when missing
- add regression test for malformed header handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afac0742608322a277f3b1ec7aa74b