### PR TITLE
Avoid empty session IDs when prefix matches entire stem

### DIFF
--- a/src/echopress/ingest/indexer.py
+++ b/src/echopress/ingest/indexer.py
@@ -25,13 +25,15 @@ def _session_id(path: Path, patterns: Iterable[str] = ()) -> str:
     The stem (basename without extensions) is normalised to lower case so
     lookups are case-insensitive. If the stem starts with any of the
     supplied ``patterns`` (also compared in lower case) the matching prefix is
-    stripped before returning the identifier.
+    stripped before returning the identifier.  If stripping a recognised
+    prefix would yield an empty string, the original stem is returned.
     """
 
     stem = path.stem.lower()
     for prefix in sorted((p.lower() for p in patterns), key=len, reverse=True):
         if stem.startswith(prefix):
-            return stem[len(prefix) :]
+            suffix = stem[len(prefix) :]
+            return suffix or stem
     return stem
 
 

--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -42,3 +42,12 @@ def test_dataset_indexer_accepts_regex_patterns(tmp_path):
     assert "voltprsr123" in indexer.pstreams
     assert csv_path in indexer.pstreams["voltprsr123"]
 
+
+def test_dataset_indexer_handles_prefix_only(tmp_path):
+    csv_path = tmp_path / "voltprsr.csv"
+    csv_path.write_text("timestamp\n0.0\n")
+    indexer = DatasetIndexer(tmp_path)
+    assert "" not in indexer.pstreams
+    assert "voltprsr" in indexer.pstreams
+    assert csv_path in indexer.pstreams["voltprsr"]
+


### PR DESCRIPTION
## Summary
- ensure `_session_id` falls back to the full stem when stripping a configured prefix leaves nothing
- test that indexing a `voltprsr.csv` file stores it under `"voltprsr"` and does not create an empty session ID

## Testing
- `pytest tests/test_indexer_pstream_csv.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb596b22483228389e9239a7601e3