### PR TITLE
Avoid stripping prefixes from P-stream CSV session IDs

### DIFF
--- a/src/echopress/ingest/indexer.py
+++ b/src/echopress/ingest/indexer.py
@@ -75,7 +75,7 @@ class DatasetIndexer:
             if not path.is_file():
                 continue
             if _is_pstream_csv(path, self.settings.ingest.pstream_csv_patterns):
-                sid = _session_id(path, self.settings.ingest.pstream_csv_patterns)
+                sid = path.stem.lower()
                 self.pstreams.setdefault(sid, []).append(path)
                 continue
             sid = _session_id(path)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -56,7 +56,7 @@ def test_index_align_adapt(tmp_path):
     assert result.exit_code == 0
     data = json.loads(cache_path.read_text())
     assert "s1" in data["ostreams"]
-    assert "001" in data["pstreams"]
+    assert "voltprsr001" in data["pstreams"]
 
     result = runner.invoke(app, ["align", "--export", str(align_path)], obj=cfg)
     assert result.exit_code == 0

--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -6,9 +6,10 @@ def test_dataset_indexer_picks_up_voltprsr_csv(tmp_path):
     csv_path = tmp_path / "voltprsr001.csv"
     csv_path.write_text("timestamp\n0.0\n")
     indexer = DatasetIndexer(tmp_path)
-    assert "001" in indexer.pstreams
-    assert csv_path in indexer.pstreams["001"]
-    assert "001" not in indexer.ostreams
+    sid = "voltprsr001"
+    assert sid in indexer.pstreams
+    assert csv_path in indexer.pstreams[sid]
+    assert sid not in indexer.ostreams
 
 
 def test_dataset_indexer_picks_up_multiple_patterns(tmp_path):
@@ -20,17 +21,17 @@ def test_dataset_indexer_picks_up_multiple_patterns(tmp_path):
     settings = Settings()
     settings.ingest.pstream_csv_patterns = ["voltprsr", "anotherpstream"]
     indexer = DatasetIndexer(tmp_path, settings=settings)
-    assert "001" in indexer.pstreams
-    assert "002" in indexer.pstreams
+    assert "voltprsr001" in indexer.pstreams
+    assert "anotherpstream002" in indexer.pstreams
     assert "sessiona" in indexer.ostreams
     assert "sessiona" not in indexer.pstreams
 
 
-def test_dataset_indexer_lookup_by_stripped_id(tmp_path):
+def test_dataset_indexer_lookup_by_full_id(tmp_path):
     csv_path = tmp_path / "VoltPrsr001.csv"
     csv_path.write_text("timestamp\n0.0\n")
     indexer = DatasetIndexer(tmp_path)
-    assert indexer.get_pstreams("001") == [csv_path]
+    assert indexer.get_pstreams("voltprsr001") == [csv_path]
 
 
 def test_dataset_indexer_accepts_regex_patterns(tmp_path):

--- a/tests/test_indexer_read_pstream_example.py
+++ b/tests/test_indexer_read_pstream_example.py
@@ -9,9 +9,9 @@ def test_indexer_finds_and_reads_voltprsr_example(tmp_path):
     file.write_text(data)
 
     indexer = DatasetIndexer(tmp_path)
-    assert "_example" in indexer.pstreams
+    assert "voltprsr_example" in indexer.pstreams
 
-    indexed_file = indexer.first_pstream("_example")
+    indexed_file = indexer.first_pstream("voltprsr_example")
     assert indexed_file == file
 
     records = list(read_pstream(indexed_file))


### PR DESCRIPTION
## Summary
- Ensure P-stream CSV files keep their full stem as the session identifier instead of stripping prefixes
- Adjust tests to expect full stem session IDs when indexing P-stream CSVs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afba7c0d108322be3a201cd4c9a7bb