### PR TITLE
Enforce prefix match for P-stream CSV patterns

### DIFF
--- a/src/echopress/ingest/indexer.py
+++ b/src/echopress/ingest/indexer.py
@@ -42,12 +42,13 @@ def _is_pstream_csv(path: Path, patterns: Iterable[str]) -> bool:
     if path.suffix.lower() != ".csv":
         return False
     stem = path.stem
+    stem_lower = stem.lower()
     for pattern in patterns:
         try:
-            if re.search(pattern, stem, flags=re.IGNORECASE):
+            if re.match(pattern, stem, flags=re.IGNORECASE):
                 return True
         except re.error:
-            if pattern.lower() in stem.lower():
+            if stem_lower.startswith(pattern.lower()):
                 return True
     return False
 

--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -52,3 +52,25 @@ def test_dataset_indexer_handles_prefix_only(tmp_path):
     assert "voltprsr" in indexer.pstreams
     assert csv_path in indexer.pstreams["voltprsr"]
 
+
+def test_dataset_indexer_ignores_voltprsr_in_middle(tmp_path):
+    csv_path = tmp_path / "foo_voltprsr001.csv"
+    csv_path.write_text("timestamp\n0.0\n")
+    indexer = DatasetIndexer(tmp_path)
+    sid = "foo_voltprsr001"
+    assert sid not in indexer.pstreams
+    assert sid in indexer.ostreams
+    assert csv_path in indexer.ostreams[sid]
+
+
+def test_dataset_indexer_ignores_voltprsr_in_middle_with_regex(tmp_path):
+    csv_path = tmp_path / "foo_voltprsr123.csv"
+    csv_path.write_text("timestamp\n0.0\n")
+    settings = Settings()
+    settings.ingest.pstream_csv_patterns = [r"voltprsr\d+"]
+    indexer = DatasetIndexer(tmp_path, settings=settings)
+    sid = "foo_voltprsr123"
+    assert sid not in indexer.pstreams
+    assert sid in indexer.ostreams
+    assert csv_path in indexer.ostreams[sid]
+


### PR DESCRIPTION
## Summary
- require P-stream CSV patterns to match at filename start
- ignore files with `voltprsr` appearing mid-name
- test regex and string pattern handling for mid-name cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afc43117fc8322bdb28020cfd46a4a