### PR TITLE
Preserve session ID case and support case-insensitive lookups

### DIFF
--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -23,14 +23,16 @@ def test_dataset_indexer_picks_up_multiple_patterns(tmp_path):
     indexer = DatasetIndexer(tmp_path, settings=settings)
     assert "voltprsr001" in indexer.pstreams
     assert "anotherpstream002" in indexer.pstreams
-    assert "sessiona" in indexer.ostreams
-    assert "sessiona" not in indexer.pstreams
+    assert "sessionA" in indexer.ostreams
+    assert "sessionA" not in indexer.pstreams
 
 
 def test_dataset_indexer_lookup_by_full_id(tmp_path):
     csv_path = tmp_path / "VoltPrsr001.csv"
     csv_path.write_text("timestamp\n0.0\n")
     indexer = DatasetIndexer(tmp_path)
+    assert "VoltPrsr001" in indexer.pstreams
+    assert indexer.get_pstreams("VoltPrsr001") == [csv_path]
     assert indexer.get_pstreams("voltprsr001") == [csv_path]
 
 
@@ -40,8 +42,8 @@ def test_dataset_indexer_accepts_regex_patterns(tmp_path):
     settings = Settings()
     settings.ingest.pstream_csv_patterns = [r"voltprsr\d+"]
     indexer = DatasetIndexer(tmp_path, settings=settings)
-    assert "voltprsr123" in indexer.pstreams
-    assert csv_path in indexer.pstreams["voltprsr123"]
+    assert "VoltPrsr123" in indexer.pstreams
+    assert csv_path in indexer.pstreams["VoltPrsr123"]
 
 
 def test_dataset_indexer_handles_prefix_only(tmp_path):

--- a/tests/test_ostream_csv.py
+++ b/tests/test_ostream_csv.py
@@ -20,5 +20,7 @@ def test_dataset_indexer_picks_up_csv(tmp_path):
     csv_path = tmp_path / "sessionA.csv"
     csv_path.write_text("session_id,timestamp,ch0\nsessionA,0.0,1.0\n")
     indexer = DatasetIndexer(tmp_path)
-    assert "sessiona" in indexer.ostreams
-    assert csv_path in indexer.ostreams["sessiona"]
+    assert "sessionA" in indexer.ostreams
+    assert csv_path in indexer.ostreams["sessionA"]
+    assert indexer.get_ostreams("sessionA") == [csv_path]
+    assert indexer.get_ostreams("SESSIONA") == [csv_path]


### PR DESCRIPTION
## Summary
- keep session IDs in DatasetIndexer with original casing
- maintain lower-case lookup maps for case-insensitive `get_*` helpers
- test session ID case retention and case-insensitive lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc5406d888322af484212d9ea8cf5