### PR TITLE
Add devcontainer configuration for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "echpressure2 (Codespaces)",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "hostRequirements": { "cpus": 4, "memory": "8gb", "storage": "32gb" },
+  "onCreateCommand": "pip install -U pip",
+  "postCreateCommand": "pip install -e . && pip install pytest numpy pyyaml",
+  "postStartCommand": "pytest -q || true",
+  "forwardPorts": [8888],
+  "customizations": {
+    "vscode": {
+      "settings": { "python.testing.pytestEnabled": true, "python.testing.pytestArgs": ["tests"] },
+      "extensions": ["ms-python.python","ms-toolsai.jupyter","charliermarsh.ruff"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add VS Code devcontainer config targeting Python 3.12
- specify host requirements and setup commands for codespaces

## Testing
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b1fe74e2a0832280e27ff93cc30d9a