### PR TITLE
docs: document dataset indexer behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Existing commands such as `ingest`, `calibrate` and `viz` remain available.
 
 Files like `voltprsr001.csv` hold `timestamp,pressure` pairs. The
 `DatasetIndexer` recognises the `voltprsr` prefix by default and indexes the
-trailing identifier. `read_pstream` loads these CSVs and yields
+trailing identifier. See [docs/dataset_indexer.md](docs/dataset_indexer.md) for session handling, case-insensitive lookups and pattern matching. `read_pstream` loads these CSVs and yields
 `PStreamRecord` objects with parsed timestamps and floating-point pressures.
 
 ```python

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Echpressure processes two unsynchronized data streams: a pressure stream (P-stre
 Alignment enforces a maximum allowable error ``O_max``. If the midpoint lies farther than this threshold from all P-stream timestamps, the file is rejected by default and marked in diagnostics. Setting ``reject_if_Ealign_gt_Omax=False`` retains the mapping but records the offending indices under ``E_align_violations``.
 
 ## Pipeline
-1. **Ingestion & Indexing** – Resolve dataset paths, parse file and record metadata, and build in-memory tables for fast lookup.
+1. **Ingestion & Indexing** – Resolve dataset paths, parse file and record metadata, and build in-memory tables for fast lookup. See [Dataset Indexer](dataset_indexer.md) for session lookup rules and pattern matching.
 2. **Calibration & Mapping** – Convert voltages to calibrated pressure values and compute midpoint alignment, keeping track of error bounds.
 3. **Adapters Layer 1** – Cycle-synchronous mappings such as PB-CSA, PLSTN, HMV, CEC, DTW-TA and MTP transform waveforms into fixed-length, shift-invariant representations.
 4. **Adapters Layer 2** – Transforms applied to mapped cycles including Fourier spectrum, Hilbert-envelope, wavelet energies and MFCC features.

--- a/docs/dataset_indexer.md
+++ b/docs/dataset_indexer.md
@@ -1,0 +1,26 @@
+# Dataset Indexer
+
+The `DatasetIndexer` scans a dataset directory and records pressure (`P`-stream) and oscilloscope (`O`-stream) files. Session IDs are taken from the full filename stem, so `VoltPrsr001.csv` and `sessionA.csv` become the session IDs `VoltPrsr001` and `sessionA` respectively. The raw stem is preserved to avoid any ambiguity.
+
+Lookups are case-insensitive. Internally, the indexer stores a lowercase map of session IDs so queries like `indexer.get_pstreams("VoltPrsr001")` and `indexer.get_pstreams("voltprsr001")` return the same results.
+
+P-stream CSV files are matched using configurable patterns. Each pattern may be a plain prefix or a regular expression. Matching is case-insensitive and falls back to prefix/substring checks if a pattern is not a valid regular expression.
+
+```python
+from echopress.ingest import DatasetIndexer, Settings
+
+# Build an index over /data using both prefix and regex patterns
+settings = Settings()
+settings.ingest.pstream_csv_patterns = ["voltprsr", r"anotherpstream\d+"]
+indexer = DatasetIndexer("/data", settings=settings)
+
+# Case-insensitive lookup
+indexer.get_pstreams("VoltPrsr001") == indexer.get_pstreams("voltprsr001")
+indexer.get_ostreams("sessionA") == indexer.get_ostreams("SESSIONA")
+
+# Fallback behaviour: unknown session IDs return project-wide lists
+indexer.get_pstreams("unknown")       # -> list of all P-stream paths
+indexer.get_ostreams("unknown", fallback=False)  # -> []
+```
+
+`get_pstreams` and `get_ostreams` accept a `fallback` argument. When `fallback=True` (the default) and a session ID is missing, the indexer returns all files of that type in the project. Setting `fallback=False` yields an empty list instead.


### PR DESCRIPTION
## Summary
- add Dataset Indexer docs detailing session IDs, case-insensitive lookups and pattern matching
- link dataset indexer page from architecture overview and README

## Testing
- `pytest` *(fails: PStreamRecord arguments, load_ostream_csv mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b23000b3748322bc9289a2c1139b0b