### PR TITLE
Document CSV P-stream ingestion and windowed O-stream parsing

### DIFF
--- a/plan.txt
+++ b/plan.txt
@@ -15,6 +15,8 @@ optional lazy/batched loading for large corpora.
 • Framework-agnostic outputs (NumPy-first), ready for PyTorch/TF dataset wrappers at a
 later stage.
 • Hydra-driven configuration via YAML (hierarchical, overrideable).
+• Window-mode O-stream parsing for fixed-duration windows.
+• Configurable P-stream CSV patterns for flexible record layouts.
 • Extremely modular adapters: each in its own folder with adapter.py, adapter.yml,
 README.md (math + references), and tests/.
 • Visualization: quick CLI flags to plot raw/processed/adapter outputs (e.g., random samples at given pressure ranges) or return NumPy arrays.

--- a/theory.txt
+++ b/theory.txt
@@ -53,6 +53,8 @@ v (3)
 
 (in volts).
 
+In addition to this paired-line layout, P-stream ingestion also accepts single-line records and CSV rows that place the timestamp and voltages on one line.
+
 For k ∈ {1, 2, 3}, linear calibration is
 p(k) = αk v (k) + βk .
 The canonical scalar pressure is only channel 3 :


### PR DESCRIPTION
## Summary
- note that P-stream ingestion supports single-line and CSV records
- plan for window-mode O-stream parsing and configurable P-stream CSV patterns

## Testing
- `pre-commit run --files theory.txt plan.txt` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest` *(fails: test_index_align_adapt, test_basic_alignment, test_O_max_enforcement, test_tie_break_behaviour, test_alignment_with_settings, test_derivative_and_uncertainty, test_load_ostream_csv, test_read_pstream_csv)*

------
https://chatgpt.com/codex/tasks/task_e_68b2321979548322ab847097f7e450f8