### PR TITLE
Add pinned requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+hydra-core==1.3.2
+omegaconf==2.3.0
+numpy==1.26.4
+scipy==1.11.4
+typer==0.9.0
+matplotlib==3.8.2
+pytest==8.3.2


### PR DESCRIPTION
## Summary
- Add requirements file with pinned versions for core dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: AssertionError, TypeError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b25178aa748322a3e6077b773a0427