### PR TITLE
Allow running CLI directly with argument passthrough

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -305,5 +305,8 @@ def main(cfg: DictConfig) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    if "--" in sys.argv:
+        sys.argv = [sys.argv[0]] + sys.argv[sys.argv.index("--") + 1 :]
+    app()
 


### PR DESCRIPTION
## Summary
- enable direct invocation of the Typer CLI by stripping arguments after `--`

## Testing
- `PYTHONPATH=src python3 -m src.echopress.cli -- align --dataset 3MSAMPLES082525 --duration 0.02 --O_max 0.05` *(fails: No such option: --dataset)*
- `pytest` *(fails: 8 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b26335e03883228057cea44a7005a7