### PR TITLE
Refactor align command to use dataset root index

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,17 @@ P-streams:
 # Build dataset indices from configured paths (supports .pstream and CSV)
 python -m echopress.cli index
 
-# Align O-stream files to the P-stream (.pstream or CSV) and compute uncertainty bounds
-python -m echopress.cli align
+# Align O-stream files to the P-stream using the cached index
+python -m echopress.cli align /data
 
 # Run an adapter on files within a pressure range and save features
 python -m echopress.cli adapt --adapter cec --pr-min 80 --pr-max 120 --n 5 --output features.npy
 ```
+
+The `index` command writes an `index.json` file under the dataset root. The
+`align` step consumes this digest, aligns the first O-/P-stream pair in each
+session and emits a consolidated `align.json` table.  Downstream utilities like
+`adapt` read this table to locate files by pressure value.
 
 Existing commands such as `ingest`, `calibrate` and `viz` remain available.
 
@@ -92,7 +97,7 @@ Runtime configuration is managed with [Hydra](https://hydra.cc). The default
 configuration in `conf/config.yaml` composes several YAML groups under `conf/`,
 including:
 
-* `dataset` – paths to example O- and P-streams (O-streams may be `.npz`, `.json`, or `.csv`)
+* `dataset` – dataset root directory and timestamp metadata
 * `ingest` – patterns to recognise P-stream CSV files (default `['voltprsr']`,
   matching names like `voltprsr*.csv`)
 * `mapping` – alignment and derivative parameters

--- a/conf/adapter/default.yaml
+++ b/conf/adapter/default.yaml
@@ -7,5 +7,5 @@ pr_min: null
 pr_max: null
 n: 1
 plot: false
-align_table: ${dataset.root.ostream}/align.json
+align_table: ${dataset.root}/align.json
 seed: 0

--- a/conf/dataset/default.yaml
+++ b/conf/dataset/default.yaml
@@ -1,11 +1,5 @@
-# Root directories for input streams. These can be overridden as needed.
-root:
-  ostream: .
-  pstream: .
-
-# Paths to input streams relative to the roots above.
-ostream: ${dataset.root.ostream}/sample_ostream.npz
-pstream: ${dataset.root.pstream}/sample_pstream.txt
+# Root directory for all input streams. This can be overridden as needed.
+root: .
 
 # Metadata about P-stream timestamps.
 timezone: UTC

--- a/conf/dataset/dev.yaml
+++ b/conf/dataset/dev.yaml
@@ -2,10 +2,5 @@ defaults:
   - default
 
 # Use smaller sample files for quick development runs.
-root:
-  ostream: ./dev
-  pstream: ./dev
-
-ostream: ${dataset.root.ostream}/sample_ostream_dev.npz
-pstream: ${dataset.root.pstream}/sample_pstream_dev.txt
+root: ./dev
 

--- a/docs/dataset_indexer.md
+++ b/docs/dataset_indexer.md
@@ -24,3 +24,10 @@ indexer.get_ostreams("unknown", fallback=False)  # -> []
 ```
 
 `get_pstreams` and `get_ostreams` accept a `fallback` argument. When `fallback=True` (the default) and a session ID is missing, the indexer returns all files of that type in the project. Setting `fallback=False` yields an empty list instead.
+
+The command-line workflow uses this indexer in two stages.  Running
+`python -m echopress.cli index` writes the index to `index.json` under the
+dataset root.  The `align` command reads this digest, aligns the first
+O-stream/P-stream pair for each session and exports a consolidated
+`align.json` table.  Subsequent commands such as `adapt` consume this table to
+locate files by pressure value.

--- a/src/echopress/ingest/pstream.py
+++ b/src/echopress/ingest/pstream.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Iterator, Union, TextIO, Optional
+from typing import Iterator, Union, TextIO, Optional, Tuple
 import pathlib
 import re
 import csv
@@ -62,6 +62,7 @@ def parse_timestamp(token: str) -> datetime:
 class PStreamRecord:
     timestamp: datetime
     pressure: float
+    voltages: Optional[Tuple[float, ...]] = None
 
 
 def _parse_values_line(line: str, *, col: int = 2) -> float:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -20,9 +20,7 @@ def make_cfg(tmp_path):
     cfg = OmegaConf.create(
         {
             "dataset": {
-                "root": {"ostream": str(tmp_path), "pstream": str(tmp_path)},
-                "ostream": str(o_path),
-                "pstream": str(p_path),
+                "root": str(tmp_path),
             },
             "mapping": {"tie_breaker": "earliest", "O_max": 2.0, "W": 5, "kappa": 1.0},
             "quality": {"reject_if_Ealign_gt_Omax": True, "min_records_in_W": 1},
@@ -44,11 +42,11 @@ def make_cfg(tmp_path):
             "viz": {},
         }
     )
-    return cfg, o_path, p_path, align_path
+    return cfg, align_path
 
 
 def test_index_align_adapt(tmp_path):
-    cfg, o_path, p_path, align_path = make_cfg(tmp_path)
+    cfg, align_path = make_cfg(tmp_path)
     runner = CliRunner()
 
     cache_path = tmp_path / "index.json"
@@ -58,7 +56,7 @@ def test_index_align_adapt(tmp_path):
     assert "s1" in data["ostreams"]
     assert "voltprsr001" in data["pstreams"]
 
-    result = runner.invoke(app, ["align", "--export", str(align_path)], obj=cfg)
+    result = runner.invoke(app, ["align", str(tmp_path)], obj=cfg)
     assert result.exit_code == 0
     data = json.loads(align_path.read_text())
     assert any("pressure_value" in row for row in data)


### PR DESCRIPTION
## Summary
- Update `align` CLI to accept a dataset root, consume `index.json`, and export consolidated tables to `align.json`
- Simplify dataset configuration to only require `root` and adjust adapter defaults
- Document index/align workflow and update tests to exercise new CLI behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b27820024083229a82fd9d7ef9fd07