### PR TITLE
refactor: call hydra main in CLI entrypoint

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -325,8 +325,5 @@ def main(cfg: DictConfig) -> None:
 
 
 if __name__ == "__main__":
-    import sys
-    if "--" in sys.argv:
-        sys.argv = [sys.argv[0]] + sys.argv[sys.argv.index("--") + 1 :]
-    app()
+    main()
 


### PR DESCRIPTION
## Summary
- invoke Hydra-decorated `main` when running as a script
- drop manual `sys.argv` adjustment and rely on Hydra argument handling

## Testing
- `pytest`
- `PYTHONPATH=src python -m echopress.cli`


------
https://chatgpt.com/codex/tasks/task_e_68c09c20a8c08322bd5fa9ebba8b985c