### PR TITLE
fix: use relative import for Settings

### DIFF
--- a/src/echopress/core/derivative.py
+++ b/src/echopress/core/derivative.py
@@ -14,7 +14,7 @@ from typing import Sequence
 import numpy as np
 from scipy.signal import savgol_filter
 
-from echopress.config import Settings
+from ..config import Settings
 
 
 def _validate_window(W: int, n: int) -> None:


### PR DESCRIPTION
## Summary
- fix echopress core derivative to import Settings via relative package path

## Testing
- `PYTHONPATH=src python -m echopress.cli --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b87db7ac832299e9e51bc965c8ff