### PR TITLE
Include path and line in pstream errors

### DIFF
--- a/src/echopress/ingest/__init__.py
+++ b/src/echopress/ingest/__init__.py
@@ -1,6 +1,6 @@
 """Utility modules for ingesting EchoPress datasets."""
 
-from .pstream import read_pstream, PStreamRecord, parse_timestamp
+from .pstream import read_pstream, PStreamRecord, PStreamParseError, parse_timestamp
 from .ostream import load_ostream, OStream
 from .indexer import DatasetIndexer
 
@@ -8,6 +8,7 @@ __all__ = [
     "read_pstream",
     "PStreamRecord",
     "parse_timestamp",
+    "PStreamParseError",
     "load_ostream",
     "OStream",
     "DatasetIndexer",

--- a/tests/test_pstream_csv.py
+++ b/tests/test_pstream_csv.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timezone
 
-import pytest
-
 from echopress.ingest import read_pstream
 
 
@@ -14,11 +12,3 @@ def test_read_pstream_csv(tmp_path):
     assert records[0].pressure == 1.0
     assert records[0].timestamp == datetime.fromtimestamp(0.0, tz=timezone.utc)
     assert records[0].voltages is None
-
-
-def test_read_pstream_csv_bad_headers(tmp_path):
-    data = "time,pressure\n0.0,1.0\n"
-    file = tmp_path / "bad.csv"
-    file.write_text(data)
-    with pytest.raises(ValueError):
-        list(read_pstream(file))

--- a/tests/test_pstream_errors.py
+++ b/tests/test_pstream_errors.py
@@ -1,0 +1,24 @@
+import pytest
+
+from echopress.ingest import read_pstream, PStreamParseError
+
+
+def test_read_pstream_unrecognised_line(tmp_path):
+    bad = tmp_path / "bad.txt"
+    bad.write_text("foo\n")
+    with pytest.raises(PStreamParseError) as excinfo:
+        list(read_pstream(bad))
+    msg = str(excinfo.value)
+    assert f"{bad}:1:" in msg
+    assert "Unrecognised P-stream line" in msg
+
+
+def test_read_pstream_csv_bad_headers(tmp_path):
+    data = "time,pressure\n0.0,1.0\n"
+    file = tmp_path / "bad.csv"
+    file.write_text(data)
+    with pytest.raises(PStreamParseError) as excinfo:
+        list(read_pstream(file))
+    msg = str(excinfo.value)
+    assert f"{file}:1:" in msg
+    assert "Unrecognised timestamp" in msg


### PR DESCRIPTION
## Summary
- Track line numbers while reading P-stream text
- Raise `PStreamParseError` with file path and line for malformed input
- Add tests ensuring parse errors report location details

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0d803b53c8322af3a16d3af047780