### PR TITLE
Handle zero-channel O-streams in align

### DIFF
--- a/docs/ostream.md
+++ b/docs/ostream.md
@@ -17,6 +17,10 @@ with a start time derived from its filename and a fixed duration.
 Window mode emits an empty `(2, 0)` channel matrix and sets alignment midpoint
 to `start + duration_s/2`.
 
+O-stream files that only contain timestamps (zero channels) are valid; the
+`align` command will skip them with a warning while still exporting any
+available pressure mappings.
+
 ### Sample usage
 
 ```python

--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -112,6 +112,9 @@ def align(
     ``index.json`` is missing it is built on the fly.  For each session the
     first O-stream/P-stream pair is aligned and the resulting tables are
     consolidated into ``align.json``.
+
+    O-stream files containing only timestamps (zero channels) are ignored and
+    skipped with a warning.
     """
 
     cfg: DictConfig = ctx.obj
@@ -178,7 +181,11 @@ def align(
 
         data = np.asarray(ostream.channels)
         if data.ndim == 2:
-            data = data[:, 0]
+            if data.shape[1] > 0:
+                data = data[:, 0]
+            else:
+                typer.secho(f"O-stream {o_path} has zero channels; skipping", err=True)
+                data = np.array([])
         data = np.asarray(data).reshape(-1)
         for idx, value in enumerate(data):
             signals.add(sid, file_stamp, idx, float(value))

--- a/tests/test_align_zero_channel.py
+++ b/tests/test_align_zero_channel.py
@@ -1,0 +1,35 @@
+import json
+import numpy as np
+from typer.testing import CliRunner
+
+from echopress.cli import app
+from test_cli_commands import make_cfg
+
+
+def test_align_skips_zero_channel_ostream(tmp_path):
+    cfg, align_path = make_cfg(tmp_path)
+    # Remove default files created by make_cfg
+    (tmp_path / "s1.npz").unlink()
+    (tmp_path / "voltprsr001.csv").unlink()
+
+    # Create an O-stream with only timestamps (zero channels)
+    o_path = tmp_path / "s0.npz"
+    np.savez(
+        o_path,
+        session_id="s0",
+        timestamps=np.array([0.0, 1.0, 2.0]),
+        channels=np.empty((3, 0)),
+    )
+    # Corresponding P-stream
+    p_path = tmp_path / "voltprsr002.csv"
+    p_path.write_text("timestamp,pressure\n0,10\n1,11\n2,12\n")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["align", str(tmp_path)], obj=cfg)
+    assert result.exit_code == 0
+    data = json.loads(align_path.read_text())
+    s0_rows = [row for row in data if row["sid"] == "s0"]
+    assert s0_rows
+    row = s0_rows[0]
+    assert "pressure_value" in row
+    assert "value" not in row


### PR DESCRIPTION
## Summary
- skip O-streams with zero channels in `align`
- note zero-channel handling in docs and CLI
- add regression test for timestamp-only O-streams

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0e16ed1288322b5cb083e5eeea41f