### PR TITLE
Add alignment configuration and integrate into CLI

### DIFF
--- a/conf/align/default.yaml
+++ b/conf/align/default.yaml
@@ -1,0 +1,3 @@
+duration: 0.02
+window_mode: false
+base_year: null

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -7,5 +7,6 @@ defaults:
   - units: default
   - timestamp: default
   - quality: default
+  - align: default
   - adapter: default
   - viz: default

--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -135,13 +135,13 @@ def align(
     root = Path(root)
     debug = getattr(ctx.obj, "debug", False) or debug
 
-    align_cfg = getattr(cfg, "align", {})
+    align_cfg = cfg.align
     if window_mode is None:
-        window_mode = getattr(align_cfg, "window_mode", False)
+        window_mode = align_cfg.window_mode
     if duration is None:
-        duration = getattr(align_cfg, "duration", 0.02)
+        duration = align_cfg.duration
     if base_year is None:
-        base_year = getattr(align_cfg, "base_year", None)
+        base_year = align_cfg.base_year
 
     index_path = root / "index.json"
     if index_path.exists():

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -28,6 +28,7 @@ def make_cfg(tmp_path):
             "pressure": {"scalar_channel": 2},
             "units": {"pressure": "Pa", "voltage": "V"},
             "timestamp": {"timezone": "UTC"},
+            "align": {"duration": 0.02, "window_mode": False, "base_year": None},
             "adapter": {
                 "name": "cec",
                 "output_length": 0,


### PR DESCRIPTION
## Summary
- add align configuration with default duration, window mode, and base year
- register align defaults in Hydra config
- use cfg.align for align command defaults and update tests

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0fb8ca4a08322a7083927880c3738