### PR TITLE
Refactor CLI to use Pydantic settings overrides

### DIFF
--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -126,6 +126,8 @@ class DatasetSettings(SectionModel):
         "ISO-8601, HH:MM:SS[.ffffff], floating-point seconds since the Unix epoch,\n"
         "or Mxx-Dxx-Hxx-Mxx-Sxx-U.xxx"
     )
+    ostream: str | None = None
+    pstream: str | None = None
 
 
 class AlignSettings(SectionModel):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,9 +1,9 @@
 import json
 import numpy as np
 from typer.testing import CliRunner
-from omegaconf import OmegaConf
 
 from echopress.cli import app
+from echopress.config import Settings
 
 
 def make_cfg(tmp_path):
@@ -17,7 +17,7 @@ def make_cfg(tmp_path):
     p_path = tmp_path / "voltprsr001.csv"
     p_path.write_text("timestamp,pressure\n0,10\n1,11\n2,12\n")
     align_path = tmp_path / "align.json"
-    cfg = OmegaConf.create(
+    cfg = Settings.model_validate(
         {
             "dataset": {
                 "root": str(tmp_path),


### PR DESCRIPTION
## Summary
- ensure the CLI callback preserves preloaded Settings objects, add helpers for dataset roots/alignment tables, and expose Typer options for frequently overridden paths
- update DatasetSettings to include optional stream path fields and rely on Settings instances directly when ingesting, calibrating, aligning, and adapting
- refresh the CLI integration test fixture to instantiate the new Pydantic Settings model

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df257aae908322a32f0afcf758ba5f