### PR TITLE
Recognize ai_log CSVs as p-stream inputs

### DIFF
--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -105,7 +105,9 @@ class QualitySettings(SectionModel):
 class IngestSettings(SectionModel):
     """Options controlling dataset ingestion."""
 
-    pstream_csv_patterns: list[str] = Field(default_factory=lambda: ["voltprsr"])
+    pstream_csv_patterns: list[str] = Field(
+        default_factory=lambda: ["voltprsr", "ai_log"]
+    )
 
     @field_validator("pstream_csv_patterns", mode="before")
     @classmethod

--- a/src/echopress/ingest/indexer.py
+++ b/src/echopress/ingest/indexer.py
@@ -34,8 +34,8 @@ def _is_pstream_csv(path: Path, patterns: Iterable[str] | None) -> bool:
     if path.suffix.lower() != ".csv":
         return False
     if not patterns:
-        # Sensible default for this repo
-        patterns = ("voltprsr",)
+        # Sensible defaults for this repo
+        patterns = ("voltprsr", "ai_log")
     stem = path.stem
     stem_lower = stem.lower()
     for pattern in patterns:

--- a/tests/test_indexer_pstream_csv.py
+++ b/tests/test_indexer_pstream_csv.py
@@ -12,6 +12,16 @@ def test_dataset_indexer_picks_up_voltprsr_csv(tmp_path):
     assert sid not in indexer.ostreams
 
 
+def test_dataset_indexer_picks_up_ai_log_csv(tmp_path):
+    csv_path = tmp_path / "ai_log.csv"
+    csv_path.write_text("timestamp\n0.0\n")
+    indexer = DatasetIndexer(tmp_path)
+    sid = "ai_log"
+    assert sid in indexer.pstreams
+    assert csv_path in indexer.pstreams[sid]
+    assert sid not in indexer.ostreams
+
+
 def test_dataset_indexer_picks_up_multiple_patterns(tmp_path):
     (tmp_path / "voltprsr001.csv").write_text("timestamp\n0.0\n")
     (tmp_path / "anotherpstream002.csv").write_text("timestamp\n0.0\n")


### PR DESCRIPTION
## Summary
- include the ai_log prefix in default p-stream CSV patterns and fallback classification
- ensure DatasetIndexer recognises ai_log.csv files as p-streams via regression test

## Testing
- pytest tests/test_indexer_pstream_csv.py

------
https://chatgpt.com/codex/tasks/task_e_68e0622a13e08322bca8a8a9445b23ea