### PR TITLE
Peak-locked PLSTN adapter + --set overrides + plot downsampling

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -58,6 +58,7 @@ adapter:
   pr_max: null
   n: 1
   plot: false
+  plot_max_points: 20000
   align_table: align.json
   seed: 0
 

--- a/src/echopress/adapters/plstn/adapter.py
+++ b/src/echopress/adapters/plstn/adapter.py
@@ -1,31 +1,65 @@
-from ..base import (
-    Adapter,
-    register_adapter,
-    cycle_synchronous_map,
-    ft_spectrum,
-    hilbert_envelope,
-    wavelet_energies,
-    mfcc as mfcc_transform,
-)
+from ..base import register_adapter, cycle_synchronous_map
 import numpy as np
 
 
 class PlstnAdapter:
     name = "plstn"
 
+    @staticmethod
+    def _detect_peaks(signal: np.ndarray, min_distance: int) -> np.ndarray:
+        if signal.size < 3:
+            return np.array([], dtype=int)
+        candidates = np.where(
+            (signal[1:-1] > signal[:-2]) & (signal[1:-1] >= signal[2:])
+        )[0] + 1
+        if candidates.size == 0:
+            return np.array([], dtype=int)
+        selected = [int(candidates[0])]
+        for idx in candidates[1:]:
+            idx = int(idx)
+            if idx - selected[-1] >= min_distance:
+                selected.append(idx)
+            elif signal[idx] > signal[selected[-1]]:
+                selected[-1] = idx
+        return np.array(selected, dtype=int)
+
+    @staticmethod
+    def _resample(window: np.ndarray, target_len: int) -> np.ndarray:
+        if window.size == 0:
+            return np.zeros(target_len)
+        if window.size == target_len:
+            return window
+        x_old = np.linspace(0.0, 1.0, num=window.size, endpoint=True)
+        x_new = np.linspace(0.0, 1.0, num=target_len, endpoint=True)
+        return np.interp(x_new, x_old, window)
+
     def layer1(self, signal: np.ndarray, fs: float, f0: float) -> np.ndarray:
-        return cycle_synchronous_map(signal, fs, f0)
+        cycle_len = int(fs / f0)
+        if cycle_len <= 0:
+            raise ValueError("cycle length must be positive")
+        min_distance = max(1, int(0.8 * cycle_len))
+        peaks = self._detect_peaks(signal, min_distance=min_distance)
+        if peaks.size == 0:
+            return cycle_synchronous_map(signal, fs, f0)
+        w_left = cycle_len // 2
+        w_right = cycle_len - w_left
+        windows = []
+        for peak in peaks:
+            start = peak - w_left
+            end = peak + w_right
+            if start < 0 or end > signal.size:
+                continue
+            window = signal[start:end]
+            windows.append(self._resample(window, cycle_len))
+        if not windows:
+            return cycle_synchronous_map(signal, fs, f0)
+        return np.stack(windows)
 
     def layer2(self, cycles: np.ndarray, fs: float):
-        if self.name == "fts":
-            return {"spectrum": ft_spectrum(cycles)}
-        if self.name == "hte":
-            return {"envelope": hilbert_envelope(cycles)}
-        if self.name == "wcv":
-            return {"energies": wavelet_energies(cycles)}
-        if self.name == "mfcc":
-            return {"mfcc": mfcc_transform(cycles)}
-        return {"cycles": cycles}
+        if cycles.ndim == 1:
+            cycles = cycles[None, :]
+        avg = np.median(cycles, axis=0)
+        return {"plstn": avg}
 
 
 register_adapter(PlstnAdapter())

--- a/src/echopress/config.py
+++ b/src/echopress/config.py
@@ -157,6 +157,7 @@ class AdapterSettings(SectionModel):
     pr_max: float | None = None
     n: int = 1
     plot: bool = False
+    plot_max_points: int = 20000
     align_table: str = Field(default_factory=lambda: str(Path(DatasetSettings().root) / "align.json"))
     seed: int = 0
 


### PR DESCRIPTION
### Motivation
- Improve PLSTN adapter robustness by extracting cycles locked to signal peaks and aggregating them, and avoid slow plotting on very long series by adding downsampling support.
- Make CLI configuration overrides (`--set`) reusable so overrides apply consistently in both `init` and `adapt` paths.
- Address inline diffs/comments by simplifying imports and threading plot configuration through the CLI and settings.

### Description
- Implemented peak-locked PLSTN processing in `src/echopress/adapters/plstn/adapter.py` by adding `_detect_peaks` and `_resample`, extracting peak-centered windows, resampling to a fixed cycle length, and returning a median-aggregated signature in `layer2`; also simplified adapter imports and kept `register_adapter(PlstnAdapter())`.
- Added a reusable `_apply_overrides(settings, overrides)` helper in `src/echopress/cli.py`, wired it into both `init` and `adapt` so dotted `--set` overrides are parsed, validated, and applied consistently.
- Added `plot_max_points` to `AdapterSettings` (default `20000`) in `src/echopress/config.py` and exposed a `--plot-max-points` option on `adapt`, threading the value to the plotting helper.
- Extended `viz/plot_adapter.py` to accept `max_points`, coerce multi-dimensional series to 1D by averaging channels, and downsample long series with a stride-based sampler before plotting to avoid slow rendering and blocking backends.

### Testing
- No automated tests were run for these changes; changes were committed and verified by inspection only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ea39e1ac4832296bfb5f219e93569)