### PR TITLE
Align P-stream defaults, set default pressure unit to mmHg, and clarify scalar_channel indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ formalised in `theory.pdf`.
 
  - **P-stream** – timestamped pressure measurements expressed in millimetres of
   mercury (mmHg). P-stream CSVs are conventionally named `voltprsr{ID}.csv`
-  and contain `timestamp,pressure` columns.
+  or `ai_log{ID}.csv` and contain `timestamp,pressure` columns.
 - **O-stream** – oscilloscope files containing uniformly sampled waveforms.
 
 Each O-stream file is mapped to the nearest P-stream timestamp, calibrated and
@@ -54,8 +54,8 @@ utils/ & types.py  shared utilities and data types
 ## Usage
 
 Once the CLI exposes the full pipeline, a typical flow looks like below.
-Commands accept traditional `.pstream` text files or `voltprsr*.csv`
-P-streams:
+Commands accept traditional `.pstream` text files or configured P-stream CSV
+patterns such as `voltprsr*.csv` and `ai_log*.csv`:
 
 ```bash
 # Build dataset indices from configured paths (supports .pstream and CSV)
@@ -80,9 +80,9 @@ Existing commands such as `ingest`, `calibrate` and `viz` remain available.
 
 ### P-stream CSVs
 
-Files like `voltprsr001.csv` hold `timestamp,pressure` pairs. The
-`DatasetIndexer` recognises the `voltprsr` prefix by default and indexes the
-trailing identifier. See [docs/dataset_indexer.md](docs/dataset_indexer.md) for session handling, case-insensitive lookups and pattern matching. `read_pstream` loads these CSVs and yields
+Files like `voltprsr001.csv` and `ai_log001.csv` hold `timestamp,pressure`
+pairs. The `DatasetIndexer` recognises the `voltprsr` and `ai_log` prefixes by
+default and indexes the trailing identifier. See [docs/dataset_indexer.md](docs/dataset_indexer.md) for session handling, case-insensitive lookups and pattern matching. `read_pstream` loads these CSVs and yields
 `PStreamRecord` objects with parsed timestamps and floating-point pressures.
 
 ```python
@@ -118,11 +118,12 @@ Settings can be supplied in three complementary ways:
 Key sections available in the settings schema include:
 
 * `dataset` – dataset root directory and timestamp metadata
-* `ingest` – patterns to recognise P-stream CSV files (default `['voltprsr']`,
-  matching names like `voltprsr*.csv`)
+* `ingest` – patterns to recognise P-stream CSV files (default `['voltprsr', 'ai_log']`,
+  matching names like `voltprsr*.csv` and `ai_log*.csv`)
 * `mapping` – alignment and derivative parameters
 * `calibration` – per-channel calibration coefficients
-* `pressure` – which channel contains scalar pressure data
+* `pressure` – which channel contains scalar pressure data; `pressure.scalar_channel`
+  is zero-based, so the default `2` means physical channel 3
 * `units` – display units for pressure and voltage
 * `timestamp` – parsing controls
 * `quality` – quality gates for downstream processing

--- a/conf/ingest/default.yaml
+++ b/conf/ingest/default.yaml
@@ -2,4 +2,5 @@
 # a simple substring or a regular expression.
 pstream_csv_patterns:
   - voltprsr
+  - ai_log
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -10,6 +10,7 @@ dataset:
 ingest:
   pstream_csv_patterns:
     - voltprsr
+    - ai_log
 
 mapping:
   tie_breaker: earliest
@@ -28,10 +29,11 @@ calibration:
     - 0.0
 
 pressure:
+  # Zero-based index; default 2 means physical channel 3.
   scalar_channel: 2
 
 units:
-  pressure: Pa
+  pressure: mmHg
   voltage: V
 
 timestamp:

--- a/docs/pstream.md
+++ b/docs/pstream.md
@@ -1,11 +1,14 @@
 # P-stream files
 
 P-streams record pressure measurements alongside timestamps. Files are
-conventionally named `voltprsr{ID}.csv`—for example, `voltprsr001.csv`—so the
-`DatasetIndexer` can extract the identifier and catalog them. Filename
-patterns used to identify CSVs live in
+conventionally named `voltprsr{ID}.csv` or `ai_log{ID}.csv`—for example,
+`voltprsr001.csv` or `ai_log001.csv`—so the `DatasetIndexer` can extract the
+identifier and catalog them. Filename patterns used to identify CSVs live in
 `conf/ingest/default.yaml` under `pstream_csv_patterns` and may be extended to
 match additional naming schemes.
+
+For paired-line records and scalar pressure extraction, channel selectors are
+zero-based: `pressure.scalar_channel: 2` means physical channel 3.
 
 `read_pstream` parses three formats:
 
@@ -20,7 +23,7 @@ match additional naming schemes.
 ```python
 from echopress.ingest import DatasetIndexer, read_pstream
 
-# Locate files like 'voltprsr001.csv'
+# Locate files like 'voltprsr001.csv' or 'ai_log001.csv'
 indexer = DatasetIndexer("/data")
 pstream_file = indexer.first_pstream("001")
 


### PR DESCRIPTION
### Motivation
- Ensure configuration, docs and legacy presets consistently reflect the canonical pressure unit and CSV patterns used by the ingestion code. 
- Remove ambiguity around which channel is used for the scalar pressure by documenting indexing conventions used by the parser. 
- Make example settings easier to use by matching documentation and runtime `Settings` defaults for CSV filename patterns.

### Description
- Updated `config/example.yaml` to set `units.pressure: mmHg`, add `ai_log` to `ingest.pstream_csv_patterns`, and annotate `pressure.scalar_channel` as zero-based with the comment `# Zero-based index; default 2 means physical channel 3.`
- Updated legacy preset `conf/ingest/default.yaml` to include `ai_log` in `pstream_csv_patterns` so documented defaults match legacy presets.
- Updated `README.md` to document `ai_log` alongside `voltprsr` as default P-stream patterns and to note that `pressure.scalar_channel` is zero-based (default `2` => physical channel 3).
- Updated `docs/pstream.md` to mention `ai_log` patterns and to explicitly state that channel selectors (e.g., `pressure.scalar_channel`) are zero-based.

### Testing
- Ran `pytest tests/test_config.py tests/test_indexer_pstream_csv.py tests/test_pstream_csv.py`, which completed successfully (`13 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d4f6cfd48322934c652cd20c1c59)