### PR TITLE
Add DVC optional dependency extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.0.0"
 
 [project.optional-dependencies]
 docs = ["mkdocs"]
+dvc = ["dvc[s3]"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
### Motivation
- The README documents DVC/AWS (and DVC-on-Colab) usage but `pyproject.toml` had no matching optional dependency, so add a `dvc` extra to make installing `dvc[s3]` straightforward.

### Description
- Add `dvc = ["dvc[s3]"]` to the `[project.optional-dependencies]` section in `pyproject.toml`.

### Testing
- Ran `python -m pip install -e '.[dvc]' --dry-run` which completed successfully and ran `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d651cd60832285f04d3642ee94f4)