### PR TITLE
Add alignment revision CLI utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,34 @@ no channel data are still recorded so their paths appear in the exported table.
 Downstream utilities like `adapt` read this table to locate files by pressure
 value.
 
+### Revising alignment tables
+
+Use the alignment-revision utilities to curate `align.json` rows before adapter
+execution. `flag-low-peak` can create a removal list for files whose waveform
+peak is not larger than a baseline absolute-amplitude average, and
+`revise-align` writes the filtered alignment table for all adapters to reuse.
+
+```bash
+python -m echopress.cli flag-low-peak \
+  --dataset-root /path/to/data \
+  --align-table align.json \
+  --output-list remove_low_peak.json \
+  --baseline-samples 5000 \
+  --threshold-multiplier 3
+
+python -m echopress.cli revise-align \
+  --align-table align.json \
+  --remove-list remove_low_peak.json \
+  --output align.revised.json \
+  --match-key path
+
+python -m echopress.cli adapt \
+  --dataset-root /path/to/data \
+  --align-table align.revised.json \
+  --adapter cec \
+  --output features.npy
+```
+
 Existing commands such as `ingest`, `calibrate` and `viz` remain available.
 
 ### P-stream CSVs

--- a/docs/alignment_revision.md
+++ b/docs/alignment_revision.md
@@ -1,0 +1,70 @@
+# Alignment Revision and Waveform-Based Rejection
+
+After `align`, the project writes an alignment table, usually `align.json`.
+This table can be edited before running `adapt`.
+
+## Removing listed datapoints
+
+Use `revise-align` to remove rows from an alignment table.
+
+```bash
+python -m echopress.cli revise-align \
+  --align-table align.json \
+  --remove-list remove_list.json \
+  --output align.revised.json \
+  --match-key path
+```
+
+Supported match keys:
+
+* `path`
+* `path_basename`
+* `file_stamp`
+* `sid`
+* `sid_file_stamp`
+* `row_index`
+
+The remove list may be JSON, TXT, or CSV.
+
+## Building a remove list from waveform amplitude
+
+Use `flag-low-peak` to scan files in `align.json` and flag files whose
+maximum absolute amplitude is not larger than a baseline absolute-amplitude
+average.
+
+The rule is:
+
+```text
+max(abs(signal)) <= threshold_multiplier * mean(abs(signal[:x]))
+```
+
+where `x` is set by either `--baseline-samples` or `--baseline-seconds`.
+
+```bash
+python -m echopress.cli flag-low-peak \
+  --dataset-root /path/to/data \
+  --align-table align.json \
+  --output-list remove_low_peak.json \
+  --baseline-samples 5000 \
+  --threshold-multiplier 3
+```
+
+Then revise the alignment:
+
+```bash
+python -m echopress.cli revise-align \
+  --align-table align.json \
+  --remove-list remove_low_peak.json \
+  --output align.revised.json \
+  --match-key path
+```
+
+Finally use the revised table:
+
+```bash
+python -m echopress.cli adapt \
+  --dataset-root /path/to/data \
+  --align-table align.revised.json \
+  --adapter cec \
+  --output features.npy
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,7 @@ Alignment enforces a maximum allowable error ``O_max``. If the midpoint lies far
 ## Pipeline
 1. **Ingestion & Indexing** – Resolve dataset paths, parse file and record metadata, and build in-memory tables for fast lookup. See [Dataset Indexer](dataset_indexer.md) for session lookup rules and pattern matching.
 2. **Calibration & Mapping** – Convert voltages to calibrated pressure values and compute midpoint alignment, keeping track of error bounds.
+2.5. **Alignment Revision / Quality Filtering** – After file-level midpoint alignment, users may remove poor-quality rows using alignment metadata or waveform-derived metrics. The revised alignment table is then passed to `adapt --align-table`.
 3. **Adapters Layer 1** – Cycle-synchronous mappings such as PB-CSA, PLSTN, HMV, CEC, DTW-TA and MTP transform waveforms into fixed-length, shift-invariant representations.
 4. **Adapters Layer 2** – Transforms applied to mapped cycles including Fourier spectrum, Hilbert-envelope, wavelet energies and MFCC features.
 5. **Visualization** – Utilities to inspect raw, mapped and transformed data.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Echpressure
 nav:
   - Architecture: architecture.md
+  - Alignment Revision: alignment_revision.md
   - P-streams: pstream.md
   - Adapters:
       - CEC: adapters/cec.md

--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -125,7 +125,9 @@ def _dataset_root(settings: Settings) -> Path:
     return Path(settings.dataset.root).expanduser()
 
 
-def _resolve_align_table(settings: Settings, base_root: Path, override: Optional[Path] = None) -> Path:
+def _resolve_align_table(
+    settings: Settings, base_root: Path, override: Optional[Path] = None
+) -> Path:
     if override is not None:
         align_path = override
     else:
@@ -204,13 +206,17 @@ def init(
     if dataset_root is not None:
         settings = settings.model_copy(
             update={
-                "dataset": settings.dataset.model_copy(update={"root": str(dataset_root)})
+                "dataset": settings.dataset.model_copy(
+                    update={"root": str(dataset_root)}
+                )
             }
         )
 
     if adapter_name is not None:
         settings = settings.model_copy(
-            update={"adapter": settings.adapter.model_copy(update={"name": adapter_name})}
+            update={
+                "adapter": settings.adapter.model_copy(update={"name": adapter_name})
+            }
         )
 
     if align_table is not None:
@@ -255,8 +261,12 @@ def index(
 
     indexer = DatasetIndexer(root_path, settings=settings)
     data = {
-        "pstreams": {sid: [str(p) for p in paths] for sid, paths in indexer.pstreams.items()},
-        "ostreams": {sid: [str(o) for o in paths] for sid, paths in indexer.ostreams.items()},
+        "pstreams": {
+            sid: [str(p) for p in paths] for sid, paths in indexer.pstreams.items()
+        },
+        "ostreams": {
+            sid: [str(o) for o in paths] for sid, paths in indexer.ostreams.items()
+        },
     }
 
     cache_path = Path(cache) if cache else root_path / "index.json"
@@ -293,8 +303,8 @@ def calibrate(
     """Apply calibration coefficients to a numeric array."""
 
     settings = _get_settings(ctx)
-    data = np.loadtxt(input, delimiter=",") if input.endswith(".csv") else np.load(
-        input
+    data = (
+        np.loadtxt(input, delimiter=",") if input.endswith(".csv") else np.load(input)
     )
     calibrated = apply_calibration(data, settings=settings)
     if output:
@@ -388,7 +398,9 @@ def align(
             },
         }
 
-    all_pstreams = [p for paths in index_data.get("pstreams", {}).values() for p in paths]
+    all_pstreams = [
+        p for paths in index_data.get("pstreams", {}).values() for p in paths
+    ]
 
     signals = Signals()
     osc_files = OscFiles()
@@ -464,6 +476,146 @@ def align(
     with open(export_path, "w", encoding="utf8") as fh:
         json.dump(tables, fh, default=float)
     typer.echo(f"Exported tables to {export_path}")
+
+
+@app.command("revise-align")
+def revise_align(
+    align_table: Path = typer.Option(
+        ...,
+        "--align-table",
+        dir_okay=False,
+        file_okay=True,
+        exists=True,
+        help="Input alignment JSON table.",
+    ),
+    remove_list: Path = typer.Option(
+        ...,
+        "--remove-list",
+        dir_okay=False,
+        file_okay=True,
+        exists=True,
+        help="JSON/TXT/CSV list of datapoints to remove.",
+    ),
+    output: Path = typer.Option(
+        ...,
+        "--output",
+        "-o",
+        dir_okay=False,
+        file_okay=True,
+        exists=False,
+        help="Output revised alignment JSON.",
+    ),
+    match_key: str = typer.Option(
+        "path",
+        "--match-key",
+        help=(
+            "How to match remove-list entries to alignment rows. "
+            "Options: path, path_basename, file_stamp, sid, sid_file_stamp, row_index."
+        ),
+    ),
+    invert: bool = typer.Option(
+        False,
+        "--invert",
+        help="Invert selection: keep only rows in remove-list instead of removing them.",
+    ),
+) -> None:
+    """Revise an alignment table by removing rows listed in a remove-list."""
+
+    from .core.alignment_edit import revise_alignment_by_remove_list
+
+    summary = revise_alignment_by_remove_list(
+        align_table=align_table,
+        remove_list=remove_list,
+        output=output,
+        match_key=match_key,
+        invert=invert,
+    )
+
+    typer.echo(json.dumps(summary, indent=2))
+
+
+@app.command("flag-low-peak")
+def flag_low_peak(
+    dataset_root: Path = typer.Option(
+        ...,
+        "--dataset-root",
+        dir_okay=True,
+        file_okay=False,
+        exists=True,
+        help="Dataset root used to resolve file paths inside align.json.",
+    ),
+    align_table: Path = typer.Option(
+        ...,
+        "--align-table",
+        dir_okay=False,
+        file_okay=True,
+        exists=True,
+        help="Input alignment JSON table.",
+    ),
+    output_list: Path = typer.Option(
+        ...,
+        "--output-list",
+        "-o",
+        dir_okay=False,
+        file_okay=True,
+        exists=False,
+        help="Output JSON remove-list.",
+    ),
+    channel: int = typer.Option(
+        0,
+        "--channel",
+        help="Waveform channel index to inspect.",
+    ),
+    baseline_samples: Optional[int] = typer.Option(
+        None,
+        "--baseline-samples",
+        help="Use first X samples as baseline window.",
+    ),
+    baseline_seconds: Optional[float] = typer.Option(
+        None,
+        "--baseline-seconds",
+        help="Use first X seconds as baseline window; requires valid timestamps.",
+    ),
+    threshold_multiplier: float = typer.Option(
+        1.0,
+        "--threshold-multiplier",
+        help=(
+            "Remove if max(abs(signal)) <= multiplier * mean(abs(baseline_window)). "
+            "Use 1.0 for literal requested rule; use 2-5 for stricter peak detection."
+        ),
+    ),
+    include_missing: bool = typer.Option(
+        True,
+        "--include-missing/--skip-missing",
+        help="Include missing files in the removal list.",
+    ),
+) -> None:
+    """Create a remove-list for files whose peak amplitude is not above baseline."""
+
+    if baseline_samples is None and baseline_seconds is None:
+        raise typer.BadParameter(
+            "Specify either --baseline-samples or --baseline-seconds"
+        )
+
+    if baseline_samples is not None and baseline_seconds is not None:
+        raise typer.BadParameter(
+            "Use only one of --baseline-samples or --baseline-seconds"
+        )
+
+    from .core.amplitude_filter import build_low_peak_remove_list
+
+    summary = build_low_peak_remove_list(
+        align_table=align_table,
+        dataset_root=dataset_root,
+        output_list=output_list,
+        channel=channel,
+        baseline_samples=baseline_samples,
+        baseline_seconds=baseline_seconds,
+        threshold_multiplier=threshold_multiplier,
+        include_missing=include_missing,
+    )
+
+    typer.echo(json.dumps(summary, indent=2))
 
 
 @app.command()

--- a/src/echopress/core/alignment_edit.py
+++ b/src/echopress/core/alignment_edit.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_alignment_rows(path: str | Path) -> list[dict[str, Any]]:
+    p = Path(path)
+    rows = json.loads(p.read_text())
+    if not isinstance(rows, list):
+        raise ValueError(f"Alignment table must be a JSON list: {p}")
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError(f"Alignment table rows must be JSON objects: {p}")
+    return rows
+
+
+def save_alignment_rows(rows: list[dict[str, Any]], path: str | Path) -> Path:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(rows, indent=2, default=float))
+    return p
+
+
+def row_key(row: dict[str, Any], match_key: str, row_index: int | None = None) -> str:
+    """
+    Supported match keys:
+      - path
+      - path_basename
+      - file_stamp
+      - sid
+      - sid_file_stamp
+      - row_index
+    """
+    if match_key == "row_index":
+        if row_index is None:
+            raise ValueError("row_index matching requires row_index")
+        return str(row_index)
+
+    if match_key == "path":
+        return str(row.get("path", ""))
+
+    if match_key == "path_basename":
+        return Path(str(row.get("path", ""))).name
+
+    if match_key == "file_stamp":
+        return str(row.get("file_stamp", ""))
+
+    if match_key == "sid":
+        return str(row.get("sid", ""))
+
+    if match_key == "sid_file_stamp":
+        return f"{row.get('sid', '')}::{row.get('file_stamp', '')}"
+
+    raise ValueError(f"Unsupported match_key: {match_key}")
+
+
+def _item_key(item: Any, match_key: str) -> str:
+    """
+    Removal list can contain:
+      - strings
+      - integers for row_index
+      - objects with path/file_stamp/sid fields
+    """
+    if isinstance(item, (str, int, float)):
+        if match_key == "path_basename":
+            return Path(str(item)).name
+        return str(int(item)) if match_key == "row_index" else str(item)
+
+    if not isinstance(item, dict):
+        raise ValueError(f"Unsupported removal-list item: {item!r}")
+
+    if match_key == "sid_file_stamp":
+        return f"{item.get('sid', '')}::{item.get('file_stamp', '')}"
+
+    if match_key == "path_basename":
+        return Path(str(item.get("path", item.get("resolved_path", "")))).name
+
+    if match_key == "row_index":
+        return str(item.get("row_index", item.get("index", "")))
+
+    return str(item.get(match_key, item.get("path", "")))
+
+
+def load_remove_keys(remove_list: str | Path, match_key: str) -> set[str]:
+    """
+    Supports:
+      - JSON list of strings or objects
+      - TXT one item per line
+      - CSV with columns like path, file_stamp, sid, row_index
+    """
+    p = Path(remove_list)
+    suffix = p.suffix.lower()
+
+    if suffix == ".json":
+        data = json.loads(p.read_text())
+        if not isinstance(data, list):
+            raise ValueError("Removal JSON must be a list")
+        return {_item_key(item, match_key) for item in data}
+
+    if suffix in {".txt", ".list"}:
+        return {
+            Path(line.strip()).name if match_key == "path_basename" else line.strip()
+            for line in p.read_text().splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        }
+
+    if suffix == ".csv":
+        keys: set[str] = set()
+        with p.open("r", newline="", encoding="utf8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                keys.add(_item_key(row, match_key))
+        return keys
+
+    raise ValueError(f"Unsupported remove-list format: {p.suffix}")
+
+
+def revise_alignment_by_remove_list(
+    *,
+    align_table: str | Path,
+    remove_list: str | Path,
+    output: str | Path,
+    match_key: str = "path",
+    invert: bool = False,
+) -> dict[str, Any]:
+    rows = load_alignment_rows(align_table)
+    remove_keys = load_remove_keys(remove_list, match_key)
+
+    kept: list[dict[str, Any]] = []
+    removed: list[dict[str, Any]] = []
+
+    for idx, row in enumerate(rows):
+        key = row_key(row, match_key, row_index=idx)
+        should_remove = key in remove_keys
+
+        if invert:
+            should_remove = not should_remove
+
+        if should_remove:
+            removed.append(row)
+        else:
+            kept.append(row)
+
+    save_alignment_rows(kept, output)
+
+    return {
+        "input": str(align_table),
+        "remove_list": str(remove_list),
+        "output": str(output),
+        "match_key": match_key,
+        "input_rows": len(rows),
+        "remove_key_count": len(remove_keys),
+        "removed_rows": len(removed),
+        "kept_rows": len(kept),
+    }

--- a/src/echopress/core/amplitude_filter.py
+++ b/src/echopress/core/amplitude_filter.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from echopress.core.alignment_edit import load_alignment_rows
+from echopress.ingest import load_ostream
+
+
+def resolve_path(path: str | Path, dataset_root: str | Path) -> Path:
+    p = Path(path)
+    if p.exists():
+        return p
+
+    root = Path(dataset_root)
+    matches = list(root.rglob(p.name))
+    if matches:
+        return matches[0]
+
+    return p
+
+
+def load_signal(path: str | Path, channel: int = 0) -> tuple[np.ndarray, float | None]:
+    """
+    Returns:
+      signal: 1D waveform
+      fs: estimated sampling rate if timestamps support it, else None
+    """
+    ostream = load_ostream(path, window_mode=False)
+    channels = np.asarray(ostream.channels)
+
+    if channels.ndim == 1:
+        signal = channels.astype(float).reshape(-1)
+    elif channels.ndim == 2 and channels.shape[1] > channel:
+        signal = channels[:, channel].astype(float).reshape(-1)
+    else:
+        raise ValueError(f"No usable channel {channel} in {path}")
+
+    timestamps = np.asarray(ostream.timestamps, dtype=float)
+    fs = None
+
+    if timestamps.size > 2:
+        diffs = np.diff(timestamps)
+        diffs = diffs[np.isfinite(diffs) & (diffs > 0)]
+        if diffs.size:
+            fs = 1.0 / float(np.median(diffs))
+
+    return signal, fs
+
+
+def baseline_sample_count(
+    *,
+    baseline_samples: int | None,
+    baseline_seconds: float | None,
+    fs: float | None,
+    n_signal: int,
+) -> int:
+    if baseline_samples is not None:
+        n = int(baseline_samples)
+    elif baseline_seconds is not None:
+        if fs is None or not np.isfinite(fs) or fs <= 0:
+            raise ValueError("baseline_seconds requires valid timestamps/fs")
+        n = int(round(float(baseline_seconds) * fs))
+    else:
+        raise ValueError("Specify either baseline_samples or baseline_seconds")
+
+    if n <= 0:
+        raise ValueError("Baseline window must contain at least one sample")
+
+    return min(n, n_signal)
+
+
+def amplitude_metrics(
+    signal: np.ndarray,
+    *,
+    baseline_samples: int | None = None,
+    baseline_seconds: float | None = None,
+    fs: float | None = None,
+) -> dict[str, Any]:
+    y = np.asarray(signal, dtype=float).reshape(-1)
+
+    if y.size == 0:
+        raise ValueError("Empty signal")
+
+    n_base = baseline_sample_count(
+        baseline_samples=baseline_samples,
+        baseline_seconds=baseline_seconds,
+        fs=fs,
+        n_signal=y.size,
+    )
+
+    abs_y = np.abs(y)
+    baseline_mean_abs = float(np.mean(abs_y[:n_base]))
+    max_abs = float(np.max(abs_y))
+    peak_idx = int(np.argmax(abs_y))
+    peak_to_baseline_ratio = (
+        float(max_abs / baseline_mean_abs) if baseline_mean_abs > 0 else float("inf")
+    )
+
+    return {
+        "n_samples": int(y.size),
+        "baseline_samples_used": int(n_base),
+        "baseline_mean_abs": baseline_mean_abs,
+        "max_abs": max_abs,
+        "peak_idx": peak_idx,
+        "peak_to_baseline_ratio": peak_to_baseline_ratio,
+    }
+
+
+def build_low_peak_remove_list(
+    *,
+    align_table: str | Path,
+    dataset_root: str | Path,
+    output_list: str | Path,
+    channel: int = 0,
+    baseline_samples: int | None = None,
+    baseline_seconds: float | None = None,
+    threshold_multiplier: float = 1.0,
+    include_missing: bool = True,
+) -> dict[str, Any]:
+    """
+    Adds a row to the remove list if:
+
+        max(abs(signal)) <= threshold_multiplier * mean(abs(signal[:x]))
+
+    where x is baseline_samples, or baseline_seconds converted to samples.
+    """
+    rows = load_alignment_rows(align_table)
+
+    remove_items: list[dict[str, Any]] = []
+    checked = 0
+    kept = 0
+    missing = 0
+    errors = 0
+
+    for idx, row in enumerate(rows):
+        raw_path = row.get("path")
+        if not raw_path:
+            errors += 1
+            continue
+
+        resolved = resolve_path(str(raw_path), dataset_root)
+
+        if not resolved.exists():
+            missing += 1
+            if include_missing:
+                remove_items.append(
+                    {
+                        "row_index": idx,
+                        "path": str(raw_path),
+                        "resolved_path": str(resolved),
+                        "sid": row.get("sid"),
+                        "file_stamp": row.get("file_stamp"),
+                        "pressure_value": row.get("pressure_value"),
+                        "reason": "missing_file",
+                    }
+                )
+            continue
+
+        try:
+            signal, fs = load_signal(resolved, channel=channel)
+            metrics = amplitude_metrics(
+                signal,
+                baseline_samples=baseline_samples,
+                baseline_seconds=baseline_seconds,
+                fs=fs,
+            )
+            checked += 1
+
+            threshold = threshold_multiplier * metrics["baseline_mean_abs"]
+            should_remove = metrics["max_abs"] <= threshold
+
+            if should_remove:
+                remove_items.append(
+                    {
+                        "row_index": idx,
+                        "path": str(raw_path),
+                        "resolved_path": str(resolved),
+                        "sid": row.get("sid"),
+                        "file_stamp": row.get("file_stamp"),
+                        "pressure_value": row.get("pressure_value"),
+                        "alignment_error": row.get("alignment_error"),
+                        "reason": "max_abs_not_bigger_than_baseline_mean_abs",
+                        "threshold_multiplier": threshold_multiplier,
+                        "threshold": threshold,
+                        **metrics,
+                    }
+                )
+            else:
+                kept += 1
+
+        except Exception as exc:
+            errors += 1
+            remove_items.append(
+                {
+                    "row_index": idx,
+                    "path": str(raw_path),
+                    "resolved_path": str(resolved),
+                    "sid": row.get("sid"),
+                    "file_stamp": row.get("file_stamp"),
+                    "pressure_value": row.get("pressure_value"),
+                    "reason": "load_or_metric_error",
+                    "error": str(exc),
+                }
+            )
+
+    out = Path(output_list)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(remove_items, indent=2, default=float))
+
+    return {
+        "align_table": str(align_table),
+        "dataset_root": str(dataset_root),
+        "output_list": str(output_list),
+        "input_rows": len(rows),
+        "checked_rows": checked,
+        "kept_rows": kept,
+        "missing_files": missing,
+        "error_rows": errors,
+        "remove_rows": len(remove_items),
+        "channel": channel,
+        "baseline_samples": baseline_samples,
+        "baseline_seconds": baseline_seconds,
+        "threshold_multiplier": threshold_multiplier,
+    }

--- a/tests/test_alignment_edit.py
+++ b/tests/test_alignment_edit.py
@@ -1,0 +1,94 @@
+import json
+
+from echopress.core.alignment_edit import revise_alignment_by_remove_list
+
+
+def _write_alignment(path):
+    rows = [
+        {
+            "path": "/a/file1.npz",
+            "sid": "s1",
+            "file_stamp": "f1",
+            "pressure_value": 1.0,
+        },
+        {
+            "path": "/b/file2.npz",
+            "sid": "s2",
+            "file_stamp": "f2",
+            "pressure_value": 2.0,
+        },
+        {
+            "path": "/c/file3.npz",
+            "sid": "s1",
+            "file_stamp": "f3",
+            "pressure_value": 3.0,
+        },
+    ]
+    path.write_text(json.dumps(rows))
+    return rows
+
+
+def _revise(tmp_path, remove_items, match_key, *, invert=False):
+    align = tmp_path / "align.json"
+    remove = tmp_path / "remove.json"
+    out = tmp_path / "align.revised.json"
+    _write_alignment(align)
+    remove.write_text(json.dumps(remove_items))
+
+    summary = revise_alignment_by_remove_list(
+        align_table=align,
+        remove_list=remove,
+        output=out,
+        match_key=match_key,
+        invert=invert,
+    )
+
+    return json.loads(out.read_text()), summary
+
+
+def test_revise_alignment_by_path(tmp_path):
+    kept, summary = _revise(tmp_path, ["/a/file1.npz"], "path")
+
+    assert [row["path"] for row in kept] == ["/b/file2.npz", "/c/file3.npz"]
+    assert summary["removed_rows"] == 1
+    assert summary["kept_rows"] == 2
+
+
+def test_revise_alignment_by_path_basename(tmp_path):
+    kept, summary = _revise(tmp_path, ["/old/location/file2.npz"], "path_basename")
+
+    assert [row["path"] for row in kept] == ["/a/file1.npz", "/c/file3.npz"]
+    assert summary["removed_rows"] == 1
+
+
+def test_revise_alignment_by_file_stamp(tmp_path):
+    kept, summary = _revise(tmp_path, [{"file_stamp": "f3"}], "file_stamp")
+
+    assert [row["file_stamp"] for row in kept] == ["f1", "f2"]
+    assert summary["removed_rows"] == 1
+
+
+def test_revise_alignment_by_sid_file_stamp(tmp_path):
+    kept, summary = _revise(
+        tmp_path,
+        [{"sid": "s1", "file_stamp": "f1"}],
+        "sid_file_stamp",
+    )
+
+    assert [row["file_stamp"] for row in kept] == ["f2", "f3"]
+    assert summary["removed_rows"] == 1
+
+
+def test_revise_alignment_by_row_index(tmp_path):
+    kept, summary = _revise(tmp_path, [1], "row_index")
+
+    assert [row["path"] for row in kept] == ["/a/file1.npz", "/c/file3.npz"]
+    assert summary["removed_rows"] == 1
+
+
+def test_revise_alignment_invert_keeps_only_listed_rows(tmp_path):
+    kept, summary = _revise(tmp_path, ["/b/file2.npz"], "path", invert=True)
+
+    assert [row["path"] for row in kept] == ["/b/file2.npz"]
+    assert summary["removed_rows"] == 2
+    assert summary["kept_rows"] == 1

--- a/tests/test_amplitude_filter.py
+++ b/tests/test_amplitude_filter.py
@@ -1,0 +1,125 @@
+import json
+from dataclasses import dataclass
+
+import numpy as np
+
+from echopress.core.amplitude_filter import (
+    amplitude_metrics,
+    build_low_peak_remove_list,
+)
+
+
+@dataclass
+class DummyOStream:
+    timestamps: np.ndarray
+    channels: np.ndarray
+
+
+def _save_alignment(tmp_path, rows):
+    align = tmp_path / "align.json"
+    align.write_text(json.dumps(rows))
+    return align
+
+
+def _touch_data(tmp_path, *names):
+    for name in names:
+        (tmp_path / name).write_text("placeholder")
+
+
+def test_flat_signal_gets_flagged(monkeypatch, tmp_path):
+    _touch_data(tmp_path, "flat.npz")
+    align = _save_alignment(
+        tmp_path,
+        [{"path": str(tmp_path / "flat.npz"), "sid": "s1", "file_stamp": "flat"}],
+    )
+    out = tmp_path / "remove.json"
+
+    def fake_load_ostream(path, window_mode=False):
+        return DummyOStream(
+            timestamps=np.arange(5, dtype=float),
+            channels=np.ones((5, 1), dtype=float),
+        )
+
+    monkeypatch.setattr(
+        "echopress.core.amplitude_filter.load_ostream", fake_load_ostream
+    )
+
+    summary = build_low_peak_remove_list(
+        align_table=align,
+        dataset_root=tmp_path,
+        output_list=out,
+        baseline_samples=2,
+        threshold_multiplier=1.0,
+    )
+
+    items = json.loads(out.read_text())
+    assert summary["remove_rows"] == 1
+    assert items[0]["reason"] == "max_abs_not_bigger_than_baseline_mean_abs"
+    assert items[0]["max_abs"] == 1.0
+    assert items[0]["baseline_mean_abs"] == 1.0
+
+
+def test_signal_with_large_peak_is_kept(monkeypatch, tmp_path):
+    _touch_data(tmp_path, "peak.npz")
+    align = _save_alignment(
+        tmp_path,
+        [{"path": str(tmp_path / "peak.npz"), "sid": "s1", "file_stamp": "peak"}],
+    )
+    out = tmp_path / "remove.json"
+
+    def fake_load_ostream(path, window_mode=False):
+        return DummyOStream(
+            timestamps=np.arange(6, dtype=float),
+            channels=np.array([[1.0], [1.0], [1.0], [10.0], [1.0], [1.0]]),
+        )
+
+    monkeypatch.setattr(
+        "echopress.core.amplitude_filter.load_ostream", fake_load_ostream
+    )
+
+    summary = build_low_peak_remove_list(
+        align_table=align,
+        dataset_root=tmp_path,
+        output_list=out,
+        baseline_samples=3,
+        threshold_multiplier=3.0,
+    )
+
+    assert json.loads(out.read_text()) == []
+    assert summary["kept_rows"] == 1
+    assert summary["remove_rows"] == 0
+
+
+def test_missing_file_can_be_included(tmp_path):
+    align = _save_alignment(
+        tmp_path,
+        [{"path": str(tmp_path / "missing.npz"), "sid": "s1", "file_stamp": "missing"}],
+    )
+    out = tmp_path / "remove.json"
+
+    summary = build_low_peak_remove_list(
+        align_table=align,
+        dataset_root=tmp_path,
+        output_list=out,
+        baseline_samples=2,
+        include_missing=True,
+    )
+
+    items = json.loads(out.read_text())
+    assert summary["missing_files"] == 1
+    assert summary["remove_rows"] == 1
+    assert items[0]["reason"] == "missing_file"
+
+
+def test_baseline_samples_and_threshold_multiplier_behave_correctly():
+    metrics = amplitude_metrics(
+        np.array([2.0, -2.0, 5.0]),
+        baseline_samples=2,
+    )
+
+    assert metrics["baseline_samples_used"] == 2
+    assert metrics["baseline_mean_abs"] == 2.0
+    assert metrics["max_abs"] == 5.0
+    assert metrics["peak_to_baseline_ratio"] == 2.5
+    assert metrics["max_abs"] <= 2.5 * metrics["baseline_mean_abs"]
+    assert not (metrics["max_abs"] <= 2.0 * metrics["baseline_mean_abs"])


### PR DESCRIPTION
### Motivation
- Provide dataset curation utilities to edit `align.json` tables and perform waveform-based quality filtering before running adapters. 
- Implement a simple, reproducible rule to flag files whose peak amplitude is not larger than a baseline amplitude estimate using either a sample-count or a seconds-based baseline window. 
- Expose these workflows as CLI utilities so revised alignment tables can be consumed by existing `adapt` runs. 

### Description
- Add `src/echopress/core/alignment_edit.py` with helpers to load/save alignment rows, derive matching keys (`path`, `path_basename`, `file_stamp`, `sid`, `sid_file_stamp`, `row_index`), parse remove-lists (JSON/TXT/CSV) and write a revised `align.json` via `revise_alignment_by_remove_list`. 
- Add `src/echopress/core/amplitude_filter.py` with waveform helpers to resolve file paths, load signals via `load_ostream()`, compute baseline/peak amplitude metrics and emit a remove-list when `max(abs(signal)) <= threshold_multiplier * mean(abs(signal[:x]))`. 
- Add two CLI commands to `src/echopress/cli.py`: `flag-low-peak` to build a remove-list from waveform amplitude (supports `--baseline-samples` or `--baseline-seconds`, `--threshold-multiplier`, `--include-missing`) and `revise-align` to write a filtered alignment table using multiple match keys and optional `--invert`. 
- Add documentation `docs/alignment_revision.md`, update `docs/architecture.md`, `README.md` and `mkdocs.yml`, and include unit tests `tests/test_alignment_edit.py` and `tests/test_amplitude_filter.py` covering matching modes, inverted selection, flat-signal flagging, peak retention, missing-file handling and baseline/threshold math. 

### Testing
- Ran the test suite with `pytest` and all tests passed: `63 passed, 1 skipped`. 
- Executed the new unit tests (`tests/test_alignment_edit.py`, `tests/test_amplitude_filter.py`) as part of the run and they passed. 
- Verified the CLI surface with `PYTHONPATH=src python -m echopress.cli --help` which lists the new `flag-low-peak` and `revise-align` commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a650436648322aa2f39727066a79e)