### PR TITLE
Add configurable RMCPE artifact output and high-window-count warning

### DIFF
--- a/src/echopress/core/rmcpe.py
+++ b/src/echopress/core/rmcpe.py
@@ -150,12 +150,21 @@ def _fit_file(file_id: str, signal: np.ndarray, cfg: RMCPEConfig) -> FileFitResu
     )
 
 
-def run_rmcpe(files: Sequence[Any], config: RMCPEConfig, adapters: Any = None) -> tuple[dict[str, Any], pd.DataFrame]:
+def run_rmcpe(
+    files: Sequence[Any],
+    config: RMCPEConfig,
+    adapters: Any = None,
+    output_dir: Path | None = None,
+    write_artifacts: bool = True,
+) -> tuple[dict[str, Any], pd.DataFrame]:
+    target_dir = output_dir or Path.cwd()
     results: list[FileFitResult] = []
+    signal_lens: dict[str, int] = {}
     for i, f in enumerate(files):
         file_id = str(getattr(f, "name", f"file_{i}"))
         try:
             signal = _extract_signal(f, adapters)
+            signal_lens[file_id] = int(signal.size)
             res = _fit_file(file_id, signal, config)
         except Exception as exc:  # pragma: no cover
             LOGGER.exception("rmcpe failed for %s", file_id)
@@ -200,6 +209,26 @@ def run_rmcpe(files: Sequence[Any], config: RMCPEConfig, adapters: Any = None) -
         "T_bootstrap_ci": [ci_low, ci_high],
     }
 
-    Path("window_period_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
-    df.to_csv("window_period_per_file.csv", index=False)
+    if not accepted.empty:
+        median_n_peaks = float(np.median(accepted["n_peaks"].to_numpy(dtype=float)))
+        implied_counts: list[float] = []
+        for row in accepted.itertuples(index=False):
+            file_len = signal_lens.get(row.file_id)
+            if file_len is None or row.T_i is None or row.T_i <= 0:
+                continue
+            implied_counts.append(float(file_len / row.T_i))
+        if implied_counts:
+            implied_median = float(np.median(np.asarray(implied_counts, dtype=float)))
+            if implied_median >= 300 or (median_n_peaks >= 500 and implied_median >= 200):
+                LOGGER.warning(
+                    "rmcpe detected very high implied window counts (median≈%.1f, median accepted n_peaks≈%.1f); "
+                    "this may indicate micro-period lock. Consider a macro-window detector.",
+                    implied_median,
+                    median_n_peaks,
+                )
+
+    if write_artifacts:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / "window_period_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        df.to_csv(target_dir / "window_period_per_file.csv", index=False)
     return summary, df

--- a/tests/test_rmcpe.py
+++ b/tests/test_rmcpe.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import numpy as np
 
@@ -6,6 +7,7 @@ from echopress.core.rmcpe import (
     RMCPEConfig,
     _block_max_envelope,
     _fit_file,
+    run_rmcpe,
 )
 
 
@@ -70,3 +72,36 @@ def test_comb_score_prefers_true_period_over_2x_alias():
     assert true_res.accepted
     assert alias_res.accepted
     assert true_res.score > alias_res.score
+
+
+def test_run_rmcpe_no_artifact_writes_when_disabled(tmp_path):
+    files = [_impulse_train(400, 32, phase=5, amplitude=6.0, seed=4, noise=0.02)]
+    cfg = RMCPEConfig(T_min=20.0, T_max=50.0, prominence=0.1, bootstrap_count=20)
+    run_rmcpe(files, cfg, output_dir=tmp_path, write_artifacts=False)
+
+    assert not (tmp_path / "window_period_summary.json").exists()
+    assert not (tmp_path / "window_period_per_file.csv").exists()
+
+
+def test_run_rmcpe_writes_artifacts_to_output_dir(tmp_path):
+    files = [_impulse_train(400, 32, phase=5, amplitude=6.0, seed=4, noise=0.02)]
+    cfg = RMCPEConfig(T_min=20.0, T_max=50.0, prominence=0.1, bootstrap_count=20)
+    out_dir = tmp_path / "artifacts"
+    summary, df = run_rmcpe(files, cfg, output_dir=out_dir)
+
+    summary_path = out_dir / "window_period_summary.json"
+    csv_path = out_dir / "window_period_per_file.csv"
+    assert summary_path.exists()
+    assert csv_path.exists()
+    assert json.loads(summary_path.read_text())["algorithm"] == summary["algorithm"]
+    assert len(df) == len(files)
+
+
+def test_run_rmcpe_warns_for_likely_micro_period_lock(caplog):
+    files = [_impulse_train(20000, 20, phase=0, amplitude=3.0, seed=1, noise=0.0)]
+    cfg = RMCPEConfig(T_min=15.0, T_max=25.0, prominence=0.1, bootstrap_count=20)
+
+    with caplog.at_level("WARNING"):
+        run_rmcpe(files, cfg, output_dir=Path.cwd(), write_artifacts=False)
+
+    assert any("micro-period lock" in rec.message for rec in caplog.records)


### PR DESCRIPTION
### Motivation
- Provide callers of `run_rmcpe` control over where artifacts are written and whether to write them at all, and surface scale-related warnings when per-file implied window counts are extremely high.

### Description
- Change `run_rmcpe` signature to `output_dir: Path | None = None` and `write_artifacts: bool = True` and resolve `target_dir = output_dir or Path.cwd()` to determine artifact destination.
- Record each input signal length and only write `window_period_summary.json` and `window_period_per_file.csv` when `write_artifacts` is true, placing files under `target_dir`.
- Add scale-warning heuristics that compute accepted-file median `n_peaks`, estimate per-file implied window counts as `signal_len / T_i`, and emit a `LOGGER.warning` recommending a macro-window detector when implied counts exceed configured thresholds.
- Add tests in `tests/test_rmcpe.py` to verify no writes when `write_artifacts=False`, that writes go to `output_dir` when provided, and that the warning branch is exercised with a synthetic high-count case.

### Testing
- Added unit tests in `tests/test_rmcpe.py` covering artifact suppression, artifact output directory, and high-count warning behavior; these tests are present but were not fully executed in this environment.
- Attempted to run `pytest -q tests/test_rmcpe.py tests/test_tciml.py`, but test collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'pandas'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1266844ec08322bfb9268766386636)