### PR TITLE
TCIML: use per-file phase, vectorized NCC, and artifact output controls

### DIFF
--- a/src/echopress/core/tciml.py
+++ b/src/echopress/core/tciml.py
@@ -29,6 +29,7 @@ class TCIMLConfig:
     W_plus: int = 8
     envelope_rel_threshold: float = 0.35
     template_peak_prominence: float = 0.0
+    use_supplied_phase: bool = True
 
 
 def _extract_signal(file_obj: Any, adapters: Any) -> np.ndarray:
@@ -90,10 +91,16 @@ def _ncc(signal: np.ndarray, template: np.ndarray) -> np.ndarray:
     if signal.size < w:
         return np.asarray([], dtype=float)
     conv = correlate(signal, t[::-1], mode="valid")
+    csum = np.concatenate(([0.0], np.cumsum(signal, dtype=float)))
+    csum_sq = np.concatenate(([0.0], np.cumsum(np.square(signal, dtype=float), dtype=float)))
+    seg_sum = csum[w:] - csum[:-w]
+    seg_sq_sum = csum_sq[w:] - csum_sq[:-w]
+    seg_mean = seg_sum / w
+    seg_var = np.maximum(seg_sq_sum / w - np.square(seg_mean), 0.0)
+    seg_norm = np.sqrt(seg_var * w)
     out = np.zeros_like(conv, dtype=float)
-    for i in range(conv.size):
-        seg = _norm(signal[i : i + w])
-        out[i] = float(np.dot(seg, t))
+    valid = seg_norm > 1e-12
+    out[valid] = conv[valid] / seg_norm[valid]
     return out
 
 
@@ -131,12 +138,18 @@ def run_tciml(
     per_file_period_df: pd.DataFrame,
     config: TCIMLConfig,
     adapters: Any = None,
+    output_dir: Path | None = None,
+    write_artifacts: bool = True,
 ) -> pd.DataFrame:
-    del period_summary, per_file_period_df
-
+    output_dir = Path(output_dir) if output_dir is not None else Path(".")
+    output_dir.mkdir(parents=True, exist_ok=True)
     rows: list[dict[str, Any]] = []
     file_signals: list[np.ndarray] = []
     file_ids: list[str] = []
+    per_file_period_lookup: dict[str, dict[str, Any]] = {}
+
+    if not per_file_period_df.empty and "file_id" in per_file_period_df.columns:
+        per_file_period_lookup = per_file_period_df.set_index("file_id").to_dict(orient="index")
 
     for i, f in enumerate(files):
         file_id = str(getattr(f, "name", f"file_{i}"))
@@ -145,16 +158,33 @@ def run_tciml(
         file_signals.append(sig)
 
     raw_template, env_template = _build_template(file_signals, config)
-    np.save("incident_template.npy", raw_template)
-    if env_template is not None:
-        np.save("incident_template_env.npy", env_template)
+    if write_artifacts:
+        np.save(output_dir / "incident_template.npy", raw_template)
+        if env_template is not None:
+            np.save(output_dir / "incident_template_env.npy", env_template)
 
     w = config.peak_width_samples
     for file_id, sig in zip(file_ids, file_signals):
         N = sig.size
-        cand_peaks, _ = find_peaks(np.abs(sig), distance=max(1, int(0.5 * config.T_hat)))
-        phase = _estimate_phase(cand_peaks.astype(float), config.T_hat)
-        expected = _expected_centers(N, phase, config)
+        file_period = per_file_period_lookup.get(file_id, {})
+        supplied_period = file_period.get("T_i")
+        supplied_phase = file_period.get("phase_i")
+        use_supplied_phase = (
+            config.use_supplied_phase
+            and supplied_phase is not None
+            and not pd.isna(supplied_phase)
+            and supplied_period is not None
+            and not pd.isna(supplied_period)
+        )
+        T_i = float(supplied_period) if use_supplied_phase else float(period_summary.get("T_hat", config.T_hat))
+        if use_supplied_phase:
+            phase = float(supplied_phase)
+        else:
+            cand_peaks, _ = find_peaks(np.abs(sig), distance=max(1, int(0.5 * T_i)))
+            phase = _estimate_phase(cand_peaks.astype(float), T_i)
+
+        local_cfg = TCIMLConfig(**{**asdict(config), "T_hat": T_i})
+        expected = _expected_centers(N, phase, local_cfg)
         env = _extract_envelope(file_id, adapters, sig)
 
         for mu in expected:
@@ -230,7 +260,8 @@ def run_tciml(
             )
 
     marker_df = pd.DataFrame(rows)
-    marker_df.to_csv("incident_marker_table.csv", index=False)
+    if write_artifacts:
+        marker_df.to_csv(output_dir / "incident_marker_table.csv", index=False)
 
     meta = {
         "algorithm": "tciml",
@@ -239,5 +270,6 @@ def run_tciml(
         "n_markers": int(marker_df.shape[0]),
         "n_accepted": int(marker_df["accepted"].sum()) if not marker_df.empty else 0,
     }
-    Path("incident_marker_summary.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    if write_artifacts:
+        (output_dir / "incident_marker_summary.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
     return marker_df

--- a/tests/test_tciml.py
+++ b/tests/test_tciml.py
@@ -40,6 +40,25 @@ def test_normalized_ncc_peak_localization_near_expected_phase():
     assert abs((peak + template.size // 2) - 32) <= 1
 
 
+def test_ncc_regression_matches_prior_loop_behavior():
+    rng = np.random.default_rng(123)
+    signal = rng.normal(size=48)
+    template = rng.normal(size=7)
+
+    def old_ncc(sig, tpl):
+        t = (tpl - np.mean(tpl)) / np.linalg.norm(tpl - np.mean(tpl))
+        out = np.zeros(sig.size - tpl.size + 1, dtype=float)
+        for i in range(out.size):
+            seg = sig[i : i + tpl.size]
+            seg = seg - np.mean(seg)
+            norm = np.linalg.norm(seg)
+            seg = np.zeros_like(seg) if norm <= 1e-12 else seg / norm
+            out[i] = float(np.dot(seg, t))
+        return out
+
+    np.testing.assert_allclose(_ncc(signal, template), old_ncc(signal, template), rtol=1e-12, atol=1e-12)
+
+
 def test_onset_end_extraction_threshold_fallback_behavior(tmp_path):
     sig = np.zeros(160)
     sig[40] = 4.0
@@ -72,6 +91,29 @@ def test_onset_end_extraction_threshold_fallback_behavior(tmp_path):
     assert row["end_idx"] == row["matched_center_idx"] + cfg.W_plus
 
 
+def test_supplied_phase_used_when_enabled():
+    files = [_pulse_signal(120, centers=[35, 65, 95], width=1, amp=5.0, noise=0.0)]
+    cfg = TCIMLConfig(T_hat=30.0, T_error_samples=1.0, peak_width_samples=2, C_min=-1.0, use_supplied_phase=True)
+    period_df = pd.DataFrame([{"file_id": "file_0", "T_i": 30.0, "phase_i": 5.0, "accepted": True, "score": 1.0}])
+    out = run_tciml(files, {"T_hat": 30.0}, period_df, cfg, write_artifacts=False)
+    assert not out.empty
+    assert (out["expected_center_idx"] == 35).any()
+
+
+def test_fallback_phase_used_when_disabled_or_missing():
+    files = [_pulse_signal(120, centers=[35, 65, 95], width=1, amp=5.0, noise=0.0)]
+    supplied = pd.DataFrame([{"file_id": "file_0", "T_i": 30.0, "phase_i": 5.0, "accepted": True, "score": 1.0}])
+    missing = pd.DataFrame([{"file_id": "file_0", "T_i": 30.0, "phase_i": np.nan, "accepted": True, "score": 1.0}])
+
+    cfg_disabled = TCIMLConfig(T_hat=30.0, T_error_samples=1.0, peak_width_samples=2, C_min=-1.0, use_supplied_phase=False)
+    out_disabled = run_tciml(files, {"T_hat": 30.0}, supplied, cfg_disabled, write_artifacts=False)
+    assert (out_disabled["expected_center_idx"] == 35).any()
+
+    cfg_enabled = TCIMLConfig(T_hat=30.0, T_error_samples=1.0, peak_width_samples=2, C_min=-1.0, use_supplied_phase=True)
+    out_missing = run_tciml(files, {"T_hat": 30.0}, missing, cfg_enabled, write_artifacts=False)
+    assert (out_missing["expected_center_idx"] == 35).any()
+
+
 def test_marker_rejection_reasons_low_score_and_high_residual(tmp_path):
     sig = np.zeros(220)
     sig[120] = 5.0
@@ -99,6 +141,24 @@ def test_marker_rejection_reasons_low_score_and_high_residual(tmp_path):
     assert (~out["accepted"]).any()
     assert out["reject_reason"].str.contains("score_low").any()
     assert out["reject_reason"].str.contains("residual_large").any()
+
+
+def test_output_dir_and_write_artifacts_controls(tmp_path):
+    files = [_pulse_signal(120, centers=[20, 50, 80], width=1, amp=4.0, noise=0.0)]
+    cfg = TCIMLConfig(T_hat=30.0, T_error_samples=1.0, peak_width_samples=2, C_min=-1.0)
+    period_df = pd.DataFrame([{"file_id": "file_0", "T_i": 30.0, "phase_i": 20.0, "accepted": True, "score": 1.0}])
+    out_dir = tmp_path / "artifacts"
+
+    run_tciml(files, {"T_hat": 30.0}, period_df, cfg, output_dir=out_dir, write_artifacts=True)
+    assert (out_dir / "incident_template.npy").exists()
+    assert (out_dir / "incident_marker_table.csv").exists()
+    assert (out_dir / "incident_marker_summary.json").exists()
+
+    suppressed_dir = tmp_path / "suppressed"
+    run_tciml(files, {"T_hat": 30.0}, period_df, cfg, output_dir=suppressed_dir, write_artifacts=False)
+    assert not (suppressed_dir / "incident_template.npy").exists()
+    assert not (suppressed_dir / "incident_marker_table.csv").exists()
+    assert not (suppressed_dir / "incident_marker_summary.json").exists()
 
 
 def test_serialization_schema_columns_match_documented_names(tmp_path):


### PR DESCRIPTION
### Motivation
- Allow TCIML to honor per-file period/phase when available and only fall back to an estimated phase when the supplied phase is missing or disabled.  
- Replace the slow per-window loop in normalized cross-correlation with a vectorized implementation for performance and numerical parity.  
- Provide configurable artifact routing and the ability to suppress writing files to make `run_tciml(...)` more flexible for tests and different execution contexts.

### Description
- Extended `TCIMLConfig` with `use_supplied_phase: bool = True` to control whether per-file supplied phase/period are used.  
- Reworked `run_tciml(...)` signature to accept `output_dir: Path | None = None` and `write_artifacts: bool = True` and route `incident_template*.npy`, `incident_marker_table.csv`, and `incident_marker_summary.json` into `output_dir` only when `write_artifacts` is true.  
- Removed the unconditional deletion of `period_summary`/`per_file_period_df` and implemented per-file lookup (by `file_id`) so the algorithm uses the supplied `T_i`/`phase_i` when present and allowed, otherwise it estimates phase as a fallback.  
- Replaced the `_ncc()` loop with a vectorized approach using `scipy.signal.correlate` plus rolling mean/variance normalization (cumulative sums) to compute normalized cross-correlation without per-window Python loops.  
- Added tests in `tests/test_tciml.py` covering: honoring supplied phase when enabled, fallback behavior when disabled or missing, artifact output routing and suppression, and a regression test asserting `_ncc()` matches the previous loop implementation on synthetic signals.

### Testing
- Added unit tests exercising the new behaviors and a numeric regression check for `_ncc()` in `tests/test_tciml.py`.  
- Ran `pytest -q tests/test_tciml.py` in the current environment and test collection failed due to a missing dependency: `ModuleNotFoundError: No module named 'pandas'`, so the new tests were not executed here.  
- Local logic-level verification was performed while authoring (synthetic signal checks and CI-intended tests added); full test execution requires installing test dependencies (`pandas`, etc.).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12676aaa98832281b546a22364ea88)