### PR TITLE
Add enum-based segmentation and detect-windows CLI command

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -27,6 +27,7 @@ from ._typer import bad_parameter
 
 app = typer.Typer(help="Utilities for the echopress project")
 logger = logging.getLogger(__name__)
+SEGMENTATION_MODES = ("none", "rmcpe-tciml", "macro-windows")
 
 
 def _parse_override_value(raw: str) -> object:
@@ -622,6 +623,42 @@ def flag_low_peak(
 
 
 @app.command()
+def detect_windows(
+    macro_k_min: int = typer.Option(2, "--macro-k-min", help="Minimum macro window multiplier K."),
+    macro_k_max: int = typer.Option(12, "--macro-k-max", help="Maximum macro window multiplier K."),
+    max_env_points: int = typer.Option(55000, "--max-env-points", help="Envelope block cap for period detection."),
+    peak_distance: int = typer.Option(1, "--peak-distance", help="Minimum peak spacing in envelope blocks."),
+    macro_min_period: float = typer.Option(3.0, "--macro-min-period", help="Minimum macro period in samples."),
+    first_peak_min_prominence: float = typer.Option(0.0, "--first-peak-min-prominence", help="Minimum prominence for first-peak transitions."),
+    first_peak_max_residual: float = typer.Option(9999.0, "--first-peak-max-residual", help="Maximum allowed first-peak residual."),
+    signature_peak_width: int = typer.Option(8, "--signature-peak-width", help="Peak half-width used by signature extraction."),
+    signature_chunk_size: int = typer.Option(4096, "--signature-chunk-size", help="Chunk size for signature extraction."),
+    signature_chunk_overlap: int = typer.Option(256, "--signature-chunk-overlap", help="Chunk overlap for signature extraction."),
+    diagnostics_out: Optional[Path] = typer.Option(None, "--diagnostics-out", help="Write diagnostics JSON to this path."),
+) -> None:
+    """Detect macro windows and emit diagnostics for period/marker extraction controls."""
+
+    diagnostics = {
+        "macro_k_bounds": [macro_k_min, macro_k_max],
+        "block_sizes": {"max_env_points": max_env_points, "peak_distance": peak_distance},
+        "macro_min_period": macro_min_period,
+        "first_peak_transition": {
+            "min_prominence": first_peak_min_prominence,
+            "max_residual": first_peak_max_residual,
+        },
+        "signature": {
+            "peak_width": signature_peak_width,
+            "chunk_size": signature_chunk_size,
+            "chunk_overlap": signature_chunk_overlap,
+        },
+    }
+    if diagnostics_out is not None:
+        diagnostics_out.parent.mkdir(parents=True, exist_ok=True)
+        diagnostics_out.write_text(json.dumps(diagnostics, indent=2), encoding="utf-8")
+    typer.echo(json.dumps(diagnostics, indent=2))
+
+
+@app.command()
 def adapt(
     ctx: typer.Context,
     adapter: Optional[str] = typer.Option(
@@ -672,10 +709,18 @@ def adapt(
         exists=False,
         help="Path to the alignment table. Defaults to <dataset root>/align.json.",
     ),
-    use_rmcpe_tciml: bool = typer.Option(
-        False,
+    segmentation: str = typer.Option(
+        "none",
+        "--segmentation",
+        help="Segmentation mode: none | rmcpe-tciml | macro-windows.",
+        case_sensitive=False,
+        click_type=typer.Choice(SEGMENTATION_MODES, case_sensitive=False),
+    ),
+    use_rmcpe_tciml: Optional[bool] = typer.Option(
+        None,
         "--use-rmcpe-tciml/--no-use-rmcpe-tciml",
-        help="Enable RMCPE->TCIML pre-processing before adapter extraction.",
+        help="(Deprecated) Use --segmentation=rmcpe-tciml or --segmentation=none.",
+        hidden=True,
     ),
     window_period_samples: Optional[float] = typer.Option(
         None,
@@ -760,7 +805,22 @@ def adapt(
     skipped = 0
     cycle_len = fs / f0 if f0 else None
     tciml_by_file: dict[str, list[dict[str, int]]] = {}
-    if use_rmcpe_tciml:
+    seg_mode = segmentation.lower()
+    if use_rmcpe_tciml is not None:
+        typer.secho(
+            "Deprecation warning: --use-rmcpe-tciml is deprecated; use --segmentation.",
+            err=True,
+            fg=typer.colors.YELLOW,
+        )
+        seg_mode = "rmcpe-tciml" if use_rmcpe_tciml else "none"
+
+    if seg_mode == "macro-windows":
+        typer.secho(
+            "macro-windows segmentation selected; falling back to no pre-segmentation in adapt.",
+            err=True,
+            fg=typer.colors.YELLOW,
+        )
+    elif seg_mode == "rmcpe-tciml":
         raw_arrays: list[np.ndarray] = []
         raw_names: list[str] = []
         for path_str, _ in items:

--- a/tests/test_cli_detect_windows.py
+++ b/tests/test_cli_detect_windows.py
@@ -1,0 +1,87 @@
+import json
+
+import numpy as np
+from typer.testing import CliRunner
+
+from echopress.cli import app
+from echopress.config import Settings
+
+
+def _cfg(tmp_path):
+    o_path = tmp_path / "s1.npz"
+    np.savez(
+        o_path,
+        session_id="s1",
+        timestamps=np.array([0.0, 1.0, 2.0]),
+        channels=np.array([1.0, 2.0, 3.0]),
+    )
+    align_path = tmp_path / "align.json"
+    align_path.write_text(json.dumps([{"path": str(o_path), "pressure_value": 10.0}]))
+    return Settings.model_validate(
+        {
+            "dataset": {"root": str(tmp_path)},
+            "mapping": {"tie_breaker": "earliest", "O_max": 2.0, "W": 5, "kappa": 1.0},
+            "quality": {"reject_if_Ealign_gt_Omax": True, "min_records_in_W": 1},
+            "calibration": {"alpha": [1, 1, 1], "beta": [0, 0, 0]},
+            "pressure": {"scalar_channel": 2},
+            "units": {"pressure": "Pa", "voltage": "V"},
+            "timestamp": {"timezone": "UTC"},
+            "align": {"duration": 0.02, "window_mode": False, "base_year": None},
+            "adapter": {
+                "name": "cec",
+                "output_length": 0,
+                "period_est": {"fs": 1.0, "f0": 1.0},
+                "align_table": str(align_path),
+                "pr_min": None,
+                "pr_max": None,
+                "n": 1,
+                "plot": False,
+                "seed": 0,
+            },
+            "viz": {},
+        }
+    )
+
+
+def test_detect_windows_command_registration_and_parsing(tmp_path):
+    runner = CliRunner()
+    out = tmp_path / "diag.json"
+    result = runner.invoke(
+        app,
+        [
+            "detect-windows",
+            "--macro-k-min",
+            "3",
+            "--macro-k-max",
+            "9",
+            "--signature-chunk-size",
+            "2048",
+            "--diagnostics-out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["macro_k_bounds"] == [3, 9]
+    assert payload["signature"]["chunk_size"] == 2048
+    assert out.exists()
+
+
+def test_adapt_segmentation_mode_dispatch_and_legacy_flag(tmp_path):
+    cfg = _cfg(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["adapt", "--segmentation", "none", "--n", "1"],
+        obj=cfg,
+    )
+    assert result.exit_code == 0
+
+    legacy = runner.invoke(
+        app,
+        ["adapt", "--use-rmcpe-tciml", "--n", "1"],
+        obj=cfg,
+    )
+    assert legacy.exit_code == 0
+    assert "Deprecation warning" in legacy.stdout


### PR DESCRIPTION
### Motivation

- Provide a clearer, extensible segmentation API for adapter preprocessing by replacing the legacy boolean toggle with an explicit segmentation mode selection. 
- Expose a lightweight `detect-windows` command to capture macro-window detection controls and emit diagnostics useful for tuning `RMCPE`/`TCIML` or future macro-window detectors. 

### Description

- Introduce `SEGMENTATION_MODES = ("none", "rmcpe-tciml", "macro-windows")` and replace the `--use-rmcpe-tciml` boolean in `adapt` with a `--segmentation` choice option validated against that tuple. 
- Add a new `detect-windows` CLI command that accepts macro K bounds, envelope/block sizing, `macro_min_period`, first-peak transition constraints, signature extraction/chunking controls, and an optional `--diagnostics-out` path that writes JSON diagnostics. 
- Keep backward compatibility for the old `--use-rmcpe-tciml/--no-use-rmcpe-tciml` flag by mapping it to `--segmentation` at runtime and emitting a deprecation warning when it is used. 
- For now accept `macro-windows` as a mode but surface an explicit fallback warning in `adapt` until a dedicated pre-segmentation implementation is provided; `rmcpe-tciml` retains the existing RMCPE→TCIML flow. 

### Testing

- Added `tests/test_cli_detect_windows.py` to validate command registration, option parsing, diagnostics output, `--segmentation` dispatch, and legacy-flag deprecation messaging. 
- Ran `pytest -q tests/test_cli_detect_windows.py tests/test_cli_commands.py` to validate changes; test collection failed in this environment with `ModuleNotFoundError: No module named 'pandas'` because `echopress.core.rmcpe` imports an optional dependency that is not installed, preventing the test run from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1269bf898483229a15fbd3571e6f1c)