### PR TITLE
Add macro window detection, global-K consensus, and signature chunking utilities

### DIFF
--- a/src/echopress/core/macro_windows.py
+++ b/src/echopress/core/macro_windows.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MacroConfig:
+    """Configuration for macro-window hypothesis fitting."""
+
+    k_candidates: tuple[float, ...]
+    phase_step: int = 1
+    envelope_mode: str = "rms"
+    envelope_window: int = 5
+    pre_span: int = 3
+    post_span: int = 6
+
+
+@dataclass(frozen=True)
+class MacroFitResult:
+    k: float
+    phase: int
+    score: float
+
+
+@dataclass(frozen=True)
+class FirstPeakConfig:
+    k: float
+    left_lookback: int = 6
+    right_lookahead: int = 8
+    periodicity_tolerance: float = 0.25
+
+
+@dataclass(frozen=True)
+class FirstPeakSelection:
+    indices: tuple[int, ...]
+    periodicity_error: float
+
+
+def _moving_reduce(x: np.ndarray, window: int, fn) -> np.ndarray:
+    if window <= 0:
+        raise ValueError("window must be positive")
+    y = np.asarray(x, dtype=float).reshape(-1)
+    if y.size == 0:
+        return y
+    if window == 1:
+        return fn(y[:, None], axis=1)
+
+    out = np.empty_like(y)
+    half = window // 2
+    for i in range(y.size):
+        lo = max(0, i - half)
+        hi = min(y.size, lo + window)
+        lo = max(0, hi - window)
+        out[i] = fn(y[lo:hi])
+    return out
+
+
+def build_envelope(signal: np.ndarray, *, mode: str = "rms", window: int = 5, eps: float = 1e-9) -> np.ndarray:
+    x = np.abs(np.asarray(signal, dtype=float).reshape(-1))
+    if mode == "rms":
+        return np.sqrt(_moving_reduce(x * x, window, np.mean))
+    if mode == "max":
+        return _moving_reduce(x, window, np.max)
+    if mode == "log_energy":
+        return np.log(_moving_reduce(x * x, window, np.mean) + eps)
+    raise ValueError(f"unknown envelope mode: {mode}")
+
+
+def flat_to_burst_score(envelope: np.ndarray, idx: int, *, pre_span: int = 3, post_span: int = 6, eps: float = 1e-9) -> float:
+    env = np.asarray(envelope, dtype=float).reshape(-1)
+    if env.size == 0:
+        return float("-inf")
+    i = int(np.clip(idx, 0, env.size - 1))
+    lo = max(0, i - pre_span)
+    pre = env[lo:i] if i > lo else env[max(0, i - 1) : i + 1]
+    hi = min(env.size, i + post_span + 1)
+    post = env[i:hi]
+    pre_level = float(np.mean(pre)) if pre.size else float(env[i])
+    post_level = float(np.mean(post)) if post.size else float(env[i])
+    return (post_level - pre_level) / (abs(pre_level) + eps)
+
+
+def fit_macro_k_phase(envelope: np.ndarray, config: MacroConfig) -> MacroFitResult:
+    env = np.asarray(envelope, dtype=float).reshape(-1)
+    best = MacroFitResult(k=float(config.k_candidates[0]), phase=0, score=float("-inf"))
+    for k in config.k_candidates:
+        step = max(1, int(round(k)))
+        for phase in range(0, step, max(1, config.phase_step)):
+            idxs = np.arange(phase, env.size, step)
+            if idxs.size == 0:
+                continue
+            scores = [
+                flat_to_burst_score(
+                    env,
+                    int(i),
+                    pre_span=config.pre_span,
+                    post_span=config.post_span,
+                )
+                for i in idxs
+            ]
+            score = float(np.median(scores))
+            if score > best.score:
+                best = MacroFitResult(k=float(k), phase=int(phase), score=score)
+    return best
+
+
+def generate_first_peak_candidates(window: np.ndarray, cfg: FirstPeakConfig) -> tuple[int, ...]:
+    x = np.asarray(window, dtype=float).reshape(-1)
+    if x.size == 0:
+        return tuple()
+    env = build_envelope(x, mode="max", window=max(3, cfg.left_lookback // 2 + 1))
+    start = min(x.size - 1, cfg.left_lookback)
+    stop = max(start + 1, min(x.size, int(round(cfg.k)) + cfg.right_lookahead))
+    region = env[start:stop]
+    if region.size == 0:
+        return tuple()
+    order = np.argsort(region)[::-1]
+    cands = tuple(int(start + i) for i in order[: min(5, order.size)])
+    return cands
+
+
+def select_periodic_first_peak_sequence(candidates_per_window: Iterable[tuple[int, ...]], *, expected_k: float, tolerance: float = 0.25) -> FirstPeakSelection:
+    cands = list(candidates_per_window)
+    if not cands:
+        return FirstPeakSelection(indices=tuple(), periodicity_error=float("inf"))
+
+    chosen: list[int] = []
+    for i, options in enumerate(cands):
+        if not options:
+            continue
+        if not chosen:
+            chosen.append(int(options[0]))
+            continue
+        target = chosen[-1] + expected_k
+        pick = min(options, key=lambda x: abs(x - target))
+        chosen.append(int(pick))
+
+    if len(chosen) < 2:
+        return FirstPeakSelection(indices=tuple(chosen), periodicity_error=float("inf"))
+
+    diffs = np.diff(chosen)
+    err = float(np.median(np.abs(diffs - expected_k)) / max(expected_k, 1e-9))
+    if err > tolerance:
+        return FirstPeakSelection(indices=tuple(), periodicity_error=err)
+    return FirstPeakSelection(indices=tuple(chosen), periodicity_error=err)
+
+
+__all__ = [
+    "MacroConfig",
+    "MacroFitResult",
+    "FirstPeakConfig",
+    "FirstPeakSelection",
+    "build_envelope",
+    "flat_to_burst_score",
+    "fit_macro_k_phase",
+    "generate_first_peak_candidates",
+    "select_periodic_first_peak_sequence",
+]

--- a/src/echopress/core/signatures.py
+++ b/src/echopress/core/signatures.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+def extract_peak_centered(signal: np.ndarray, peak_idx: int, *, left: int, right: int) -> np.ndarray:
+    x = np.asarray(signal, dtype=float).reshape(-1)
+    width = left + right + 1
+    out = np.zeros(width, dtype=float)
+    start = int(peak_idx) - left
+    stop = int(peak_idx) + right + 1
+    src_lo = max(0, start)
+    src_hi = min(x.size, stop)
+    dst_lo = src_lo - start
+    dst_hi = dst_lo + (src_hi - src_lo)
+    if src_hi > src_lo:
+        out[dst_lo:dst_hi] = x[src_lo:src_hi]
+    return out
+
+
+def write_signature_chunks(signatures: np.ndarray, out_dir: str | Path, *, chunk_size: int = 128, stem: str = "signatures") -> Path:
+    arr = np.asarray(signatures, dtype=float)
+    if arr.ndim != 2:
+        raise ValueError("signatures must be 2D")
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    records = []
+    for i in range(0, arr.shape[0], chunk_size):
+        chunk = arr[i : i + chunk_size]
+        name = f"{stem}_{i//chunk_size:04d}.npy"
+        np.save(out / name, chunk)
+        records.append((i, i + chunk.shape[0], name))
+
+    idx = np.array(records, dtype=object)
+    index_path = out / f"{stem}_index.npy"
+    np.save(index_path, idx, allow_pickle=True)
+    return index_path
+
+
+def load_signature_row(index_path: str | Path, row_index: int) -> np.ndarray:
+    idx = np.load(index_path, allow_pickle=True)
+    base = Path(index_path).parent
+    for start, end, fname in idx:
+        s, e = int(start), int(end)
+        if s <= row_index < e:
+            data = np.load(base / str(fname))
+            return data[row_index - s]
+    raise IndexError(f"row index out of range: {row_index}")
+
+
+__all__ = ["extract_peak_centered", "write_signature_chunks", "load_signature_row"]

--- a/src/echopress/core/window_consensus.py
+++ b/src/echopress/core/window_consensus.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class KAggregate:
+    k: float
+    median: float
+    trimmed_mean: float
+    count: int
+
+
+def _trimmed_mean(values: np.ndarray, trim: float) -> float:
+    vals = np.sort(np.asarray(values, dtype=float))
+    if vals.size == 0:
+        return float("nan")
+    ntrim = int(np.floor(vals.size * trim))
+    if 2 * ntrim >= vals.size:
+        return float(np.mean(vals))
+    return float(np.mean(vals[ntrim : vals.size - ntrim]))
+
+
+def aggregate_per_k(scores_by_k: dict[float, list[float]], *, trim_fraction: float = 0.1) -> dict[float, KAggregate]:
+    out: dict[float, KAggregate] = {}
+    for k, scores in scores_by_k.items():
+        vals = np.asarray(scores, dtype=float)
+        if vals.size == 0:
+            continue
+        out[float(k)] = KAggregate(
+            k=float(k),
+            median=float(np.median(vals)),
+            trimmed_mean=_trimmed_mean(vals, trim_fraction),
+            count=int(vals.size),
+        )
+    return out
+
+
+def select_global_k(aggregates: dict[float, KAggregate]) -> float:
+    if not aggregates:
+        raise ValueError("no aggregates")
+    ranked = sorted(aggregates.values(), key=lambda a: (a.trimmed_mean, a.median), reverse=True)
+    return float(ranked[0].k)
+
+
+def refit_with_global_k(per_file_candidates: dict[str, dict[float, float]], global_k: float) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for name, mapping in per_file_candidates.items():
+        if global_k in mapping:
+            out[name] = float(mapping[global_k])
+        elif mapping:
+            nearest = min(mapping, key=lambda k: abs(k - global_k))
+            out[name] = float(mapping[nearest])
+    return out
+
+
+def mad_outlier_flags(values: np.ndarray, *, z_thresh: float = 3.5) -> np.ndarray:
+    x = np.asarray(values, dtype=float)
+    if x.size == 0:
+        return np.zeros(0, dtype=bool)
+    med = np.median(x)
+    mad = np.median(np.abs(x - med))
+    if mad <= 0:
+        return np.zeros_like(x, dtype=bool)
+    mz = 0.6745 * (x - med) / mad
+    return np.abs(mz) > z_thresh
+
+
+__all__ = [
+    "KAggregate",
+    "aggregate_per_k",
+    "select_global_k",
+    "refit_with_global_k",
+    "mad_outlier_flags",
+]

--- a/tests/test_first_peak_transition.py
+++ b/tests/test_first_peak_transition.py
@@ -1,0 +1,17 @@
+from echopress.core.macro_windows import FirstPeakConfig, generate_first_peak_candidates, select_periodic_first_peak_sequence
+import numpy as np
+
+
+def test_first_peak_candidates_include_left_burst_transition():
+    w = np.zeros(60)
+    w[12] = 2.0
+    w[18] = 5.0
+    cands = generate_first_peak_candidates(w, FirstPeakConfig(k=30))
+    assert 18 in cands[:3]
+
+
+def test_periodicity_rejection_for_inconsistent_sequence():
+    candidates = [(5, 6), (20, 21), (60, 61)]
+    selected = select_periodic_first_peak_sequence(candidates, expected_k=20, tolerance=0.2)
+    assert selected.indices == tuple()
+    assert selected.periodicity_error > 0.2

--- a/tests/test_macro_windows.py
+++ b/tests/test_macro_windows.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from echopress.core.macro_windows import MacroConfig, build_envelope, fit_macro_k_phase
+
+
+def test_macro_fit_prefers_true_period_under_micro_ambiguity():
+    n = 240
+    x = np.zeros(n)
+    macro_peaks = np.arange(20, n, 40)
+    micro_peaks = np.arange(10, n, 20)
+    x[macro_peaks] = 5.0
+    x[micro_peaks] += 1.0
+
+    env = build_envelope(x, mode="max", window=5)
+    fit = fit_macro_k_phase(env, MacroConfig(k_candidates=(20.0, 40.0), envelope_mode="max", envelope_window=5))
+    assert fit.k == 40.0
+
+
+def test_build_envelope_modes():
+    x = np.array([0.0, 1.0, 2.0, 1.0, 0.0])
+    for mode in ("rms", "max", "log_energy"):
+        env = build_envelope(x, mode=mode, window=3)
+        assert env.shape == x.shape

--- a/tests/test_signature_chunks.py
+++ b/tests/test_signature_chunks.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from echopress.core.signatures import extract_peak_centered, load_signature_row, write_signature_chunks
+
+
+def test_peak_centered_extract_zero_pads_edges():
+    x = np.array([1.0, 2.0, 3.0])
+    y = extract_peak_centered(x, 0, left=2, right=2)
+    assert y.tolist() == [0.0, 0.0, 1.0, 2.0, 3.0]
+
+
+def test_chunk_write_and_indexed_load(tmp_path):
+    sig = np.arange(30.0).reshape(10, 3)
+    index = write_signature_chunks(sig, tmp_path, chunk_size=4)
+    row = load_signature_row(index, 7)
+    assert np.allclose(row, sig[7])

--- a/tests/test_window_consensus.py
+++ b/tests/test_window_consensus.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from echopress.core.window_consensus import aggregate_per_k, mad_outlier_flags, refit_with_global_k, select_global_k
+
+
+def test_consensus_aggregate_and_global_k():
+    agg = aggregate_per_k({20.0: [0.1, 0.2, 0.15], 40.0: [0.4, 0.5, 0.45]})
+    assert select_global_k(agg) == 40.0
+
+
+def test_refit_and_outlier_flags_with_weak_missing_windows():
+    refit = refit_with_global_k(
+        {
+            "a": {40.0: 10.0},
+            "b": {20.0: 7.0, 40.0: 8.0},
+            "c": {20.0: 3.0},
+        },
+        40.0,
+    )
+    assert refit["a"] == 10.0
+    assert refit["c"] == 3.0
+
+    vals = np.array([1.0, 1.2, 0.8, 1.1, 6.0])
+    flags = mad_outlier_flags(vals)
+    assert flags[-1]
+    assert not flags[0]


### PR DESCRIPTION
### Motivation
- Provide utilities to detect and score macro-scale bursts in waveform windows and to disambiguate micro vs macro periodicities. 
- Offer a small consensus layer to aggregate per-file K estimates and pick a stable global K for downstream refits. 
- Add compact on-disk signature storage with chunked `*.npy` files and an index for scalable read-by-row access.

### Description
- Add `src/echopress/core/macro_windows.py` implementing dataclasses (`MacroConfig`, `MacroFitResult`, `FirstPeakConfig`, `FirstPeakSelection`), envelope builders (`rms`, `max`, `log_energy`), flat-left→burst transition scoring, K/phase comb fitting, first-peak candidate generation, and periodicity-constrained sequence selection. 
- Add `src/echopress/core/window_consensus.py` implementing per-K aggregation (median + trimmed mean), `select_global_k` ranking, `refit_with_global_k` (with nearest-K fallback), and MAD-based outlier flags (`mad_outlier_flags`). 
- Add `src/echopress/core/signatures.py` implementing peak-centered extraction with edge zero-padding, chunked signature writer that emits `*.npy` chunk files plus a `*_index.npy` table, and indexed single-row loader `load_signature_row`. 
- Add unit tests covering macro-vs-micro ambiguity and envelope modes, first-peak transition & periodicity rejection, consensus/refit + MAD outlier behavior, and signature chunk write/load operations under synthetic fixtures in `tests/`.

### Testing
- Ran the focused test suite with `pytest -q tests/test_macro_windows.py tests/test_first_peak_transition.py tests/test_window_consensus.py tests/test_signature_chunks.py`, and all tests passed. 
- The added tests are `tests/test_macro_windows.py`, `tests/test_first_peak_transition.py`, `tests/test_window_consensus.py`, and `tests/test_signature_chunks.py` and exercise the new features end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126a870acc8322a915d89bc992d4ea)