### PR TITLE
Declare runtime dependencies and add packaging import smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,16 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "echpressure2"
 version = "0.0.0"
+dependencies = [
+    "numpy==1.26.4",
+    "scipy==1.11.4",
+    "pandas==2.2.2",
+    "typer==0.9.0",
+    "click==8.1.7",
+    "matplotlib==3.8.2",
+    "pydantic==2.7.4",
+    "pydantic-settings==2.2.1",
+]
 
 [project.optional-dependencies]
 docs = ["mkdocs"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy==1.26.4
 scipy==1.11.4
+pandas==2.2.2
 typer==0.9.0
 click==8.1.7
 matplotlib==3.8.2

--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -11,6 +11,7 @@ import os
 import random
 
 import numpy as np
+import click
 import typer
 from click.core import ParameterSource
 from pydantic import ValidationError
@@ -714,7 +715,7 @@ def adapt(
         "--segmentation",
         help="Segmentation mode: none | rmcpe-tciml | macro-windows.",
         case_sensitive=False,
-        click_type=typer.Choice(SEGMENTATION_MODES, case_sensitive=False),
+        click_type=click.Choice(SEGMENTATION_MODES, case_sensitive=False),
     ),
     use_rmcpe_tciml: Optional[bool] = typer.Option(
         None,

--- a/tests/test_packaging_imports.py
+++ b/tests/test_packaging_imports.py
@@ -1,0 +1,9 @@
+"""Packaging smoke test for runtime imports."""
+
+import importlib
+
+
+def test_runtime_module_imports() -> None:
+    """Ensure key runtime modules import without optional extras."""
+    importlib.import_module("echopress.core.rmcpe")
+    importlib.import_module("echopress.cli")


### PR DESCRIPTION
### Motivation
- Ensure core runtime libraries are declared in project metadata so installations provide required imports at runtime.
- Keep optional feature groups separate under `[project.optional-dependencies]` so extras remain distinct from core requirements.
- Add a lightweight packaging smoke test to catch undeclared runtime dependencies early in CI by importing key modules in a fresh environment.

### Description
- Add a `dependencies = [...]` list to `pyproject.toml` with pinned runtime packages including `numpy`, `scipy`, `pandas`, `typer`, `click`, `matplotlib`, `pydantic`, and `pydantic-settings`.
- Update `requirements.txt` to include `pandas==2.2.2` to keep the requirements file compatible with `pyproject.toml`.
- Add `tests/test_packaging_imports.py` which imports `echopress.core.rmcpe` and `echopress.cli` as a packaging/import smoke test.
- Fix an import-time issue in `src/echopress/cli.py` by importing `click` and using `click.Choice(...)` instead of `typer.Choice(...)` so the CLI module imports cleanly under the pinned Typer version.

### Testing
- `pip install -q -r requirements.txt` was executed and completed successfully in the test environment.
- `pytest -q tests/test_packaging_imports.py` was run and the packaging import smoke test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126b637a648322a68fbff4af205be8)