### PR TITLE
Fix nested relative alignment path resolution in macro detector

### DIFF
--- a/src/echopress/core/macro_detector.py
+++ b/src/echopress/core/macro_detector.py
@@ -106,7 +106,7 @@ def load_alignment_rows(cfg: MacroDetectorConfig) -> pd.DataFrame:
         pp = Path(str(p))
         if pp.is_absolute():
             return str(pp.resolve())
-        return str((cfg.dataset_root / pp.name).resolve())
+        return str((cfg.dataset_root / pp).resolve())
 
     rows["path"] = rows["path"].map(resolve_path)
 

--- a/tests/test_clean_align.py
+++ b/tests/test_clean_align.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+from echopress.core.macro_detector import MacroDetectorConfig, load_alignment_rows
+
+
+def test_load_alignment_rows_resolves_nested_relative_paths(tmp_path: Path):
+    dataset_root = tmp_path / "dataset"
+    nested_existing = dataset_root / "session_a" / "run_01" / "file.npz"
+    nested_existing.parent.mkdir(parents=True, exist_ok=True)
+    nested_existing.write_bytes(b"npz")
+
+    # Same basename at dataset root should not be used for nested relative path resolution.
+    wrong_root_file = dataset_root / "file.npz"
+    wrong_root_file.write_bytes(b"npz")
+
+    missing_nested = "session_a/run_01/missing.npz"
+    align_rows = [
+        {"path": "session_a/run_01/file.npz", "pressure_value": 10.0},
+        {"path": missing_nested, "pressure_value": 20.0},
+    ]
+    align_table = tmp_path / "align.json"
+    align_table.write_text(json.dumps(align_rows))
+
+    cfg = MacroDetectorConfig(
+        dataset_root=dataset_root,
+        align_table=align_table,
+        output_dir=tmp_path / "out",
+        npz_only=True,
+    )
+
+    rows = load_alignment_rows(cfg)
+
+    assert len(rows) == 1
+    assert rows.loc[0, "path"] == str(nested_existing.resolve())
+    assert rows.loc[0, "path"] != str(wrong_root_file.resolve())


### PR DESCRIPTION
### Motivation
- Preserve nested relative subpaths when resolving alignment `path` entries against the dataset root because previous logic used only the basename and collapsed subpaths.

### Description
- Change `resolve_path` in `load_alignment_rows` to return `str((cfg.dataset_root / pp).resolve())` for relative paths while leaving absolute-path handling unchanged, and add `tests/test_clean_align.py` to verify nested relative path resolution and existence filtering.

### Testing
- Ran `pytest -q tests/test_clean_align.py tests/test_alignment_edit.py` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1394a229048322b4bb30c9a898a9e5)