### PR TITLE
Add post-detection CLI commands and core modules for align clean, postprocess, FFT export, and QC plots

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -21,6 +21,10 @@ from .core.calibration import apply_calibration
 from .core.mapping import align_streams
 from .core.macro_detector import MacroDetectorConfig, run_macro_detection
 from .core.echo_peaks import EchoPeakConfig, run_echo_peak_detection
+from .core.align_cleaner import AlignCleanerConfig, run_align_clean
+from .core.peak_window_postprocess import PeakWindowPostprocessConfig, run_peak_window_postprocess
+from .core.fft_export import FFTExportConfig, run_fft_postprocessed
+from .core.qc_plots import QCPlotConfig, run_qc_plot
 from .core.rmcpe import RMCPEConfig, run_rmcpe
 from .core.tables import File2PressureMap, OscFiles, Signals, export_tables
 from .core.tciml import TCIMLConfig, run_tciml
@@ -758,6 +762,61 @@ def detect_echo_peaks(
     )
     summary = run_echo_peak_detection(cfg)
     typer.echo(json.dumps(summary, indent=2, default=float))
+
+
+@app.command("clean-align")
+def clean_align(
+    align_table: Path = typer.Option(..., "--align-table", dir_okay=False, file_okay=True, exists=True),
+    output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False),
+    config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+    alignment_error_max: Optional[float] = typer.Option(1.0, "--alignment-error-max"),
+    pressure_min: Optional[float] = typer.Option(None, "--pressure-min"),
+    pressure_max: Optional[float] = typer.Option(None, "--pressure-max"),
+) -> None:
+    summary = run_align_clean(AlignCleanerConfig(align_table=align_table, output_dir=output_dir, config=config, alignment_error_max=alignment_error_max, pressure_min=pressure_min, pressure_max=pressure_max))
+    typer.echo(json.dumps(summary, indent=2, default=float))
+
+
+@app.command("postprocess-peak-windows")
+def postprocess_peak_windows(
+    echo_dir: Path = typer.Option(..., "--echo-dir", dir_okay=True, file_okay=False, exists=True),
+    output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False),
+    config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+    max_echo_peak_order: Optional[int] = typer.Option(3, "--max-echo-peak-order"),
+) -> None:
+    summary = run_peak_window_postprocess(PeakWindowPostprocessConfig(echo_dir=echo_dir, output_dir=output_dir, config=config, max_echo_peak_order=max_echo_peak_order))
+    typer.echo(json.dumps(summary, indent=2, default=float))
+
+
+@app.command("fft-postprocessed")
+def fft_postprocessed(
+    postprocess_dir: Path = typer.Option(..., "--postprocess-dir", dir_okay=True, file_okay=False, exists=True),
+    output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False),
+    config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+    fft_bins: Optional[int] = typer.Option(256, "--fft-bins"),
+) -> None:
+    summary = run_fft_postprocessed(FFTExportConfig(postprocess_dir=postprocess_dir, output_dir=output_dir, config=config, fft_bins=fft_bins))
+    typer.echo(json.dumps(summary, indent=2, default=float))
+
+
+@app.command("plot-macro-qc")
+def plot_macro_qc(input_dir: Path = typer.Option(..., "--input-dir", dir_okay=True, file_okay=False, exists=True), output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False)) -> None:
+    typer.echo(json.dumps(run_qc_plot(QCPlotConfig(stage="macro", input_dir=input_dir, output_dir=output_dir)), indent=2))
+
+
+@app.command("plot-echo-qc")
+def plot_echo_qc(input_dir: Path = typer.Option(..., "--input-dir", dir_okay=True, file_okay=False, exists=True), output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False)) -> None:
+    typer.echo(json.dumps(run_qc_plot(QCPlotConfig(stage="echo", input_dir=input_dir, output_dir=output_dir)), indent=2))
+
+
+@app.command("plot-postprocess-qc")
+def plot_postprocess_qc(input_dir: Path = typer.Option(..., "--input-dir", dir_okay=True, file_okay=False, exists=True), output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False)) -> None:
+    typer.echo(json.dumps(run_qc_plot(QCPlotConfig(stage="postprocess", input_dir=input_dir, output_dir=output_dir)), indent=2))
+
+
+@app.command("plot-fft-qc")
+def plot_fft_qc(input_dir: Path = typer.Option(..., "--input-dir", dir_okay=True, file_okay=False, exists=True), output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False)) -> None:
+    typer.echo(json.dumps(run_qc_plot(QCPlotConfig(stage="fft", input_dir=input_dir, output_dir=output_dir)), indent=2))
 
 
 @app.command()

--- a/src/echopress/core/align_cleaner.py
+++ b/src/echopress/core/align_cleaner.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+from echopress.core.config_io import merge_config, write_resolved_config
+
+
+@dataclass(frozen=True)
+class AlignCleanerConfig:
+    align_table: Path
+    output_dir: Path
+    config: Optional[Path] = None
+    alignment_error_max: Optional[float] = 1.0
+    pressure_min: Optional[float] = None
+    pressure_max: Optional[float] = None
+
+
+def _resolve_config(cfg: AlignCleanerConfig) -> dict[str, Any]:
+    default_yml = Path(__file__).resolve().parents[3] / "configs" / "align_clean.default.yml"
+    rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=cfg.config, cli_values=asdict(cfg))
+    rcfg["align_table"] = str(cfg.align_table)
+    rcfg["output_dir"] = str(cfg.output_dir)
+    return rcfg
+
+
+def run_align_clean(cfg: AlignCleanerConfig) -> dict[str, Any]:
+    rcfg = _resolve_config(cfg)
+    out_dir = Path(rcfg["output_dir"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_resolved_config(rcfg, out_dir / "clean-align_config.resolved.yml")
+
+    rows = pd.read_json(Path(rcfg["align_table"]))
+    rows = rows.dropna(subset=["path", "pressure_value"]).copy()
+    if "alignment_error" in rows.columns and rcfg.get("alignment_error_max") is not None:
+        rows["alignment_error"] = pd.to_numeric(rows["alignment_error"], errors="coerce")
+        rows = rows[rows["alignment_error"].notna() & (rows["alignment_error"] <= float(rcfg["alignment_error_max"]))]
+    if rcfg.get("pressure_min") is not None:
+        rows = rows[rows["pressure_value"] >= float(rcfg["pressure_min"])]
+    if rcfg.get("pressure_max") is not None:
+        rows = rows[rows["pressure_value"] <= float(rcfg["pressure_max"])]
+    rows = rows.drop_duplicates(subset=["path"]).reset_index(drop=True)
+    clean_path = out_dir / "align.cleaned.json"
+    clean_path.write_text(rows.to_json(orient="records", indent=2), encoding="utf-8")
+    summary = {"input_rows": int(len(pd.read_json(Path(rcfg['align_table'])))), "output_rows": int(len(rows)), "output": str(clean_path)}
+    (out_dir / "clean_align_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary

--- a/src/echopress/core/fft_export.py
+++ b/src/echopress/core/fft_export.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+
+from echopress.core.config_io import merge_config, write_resolved_config
+
+
+@dataclass(frozen=True)
+class FFTExportConfig:
+    postprocess_dir: Path
+    output_dir: Path
+    config: Optional[Path] = None
+    fft_bins: Optional[int] = 256
+
+
+def _resolve_config(cfg: FFTExportConfig) -> dict[str, Any]:
+    default_yml = Path(__file__).resolve().parents[3] / "configs" / "fft_export.default.yml"
+    rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=cfg.config, cli_values=asdict(cfg))
+    rcfg["postprocess_dir"] = str(cfg.postprocess_dir)
+    rcfg["output_dir"] = str(cfg.output_dir)
+    return rcfg
+
+
+def run_fft_postprocessed(cfg: FFTExportConfig) -> dict[str, Any]:
+    rcfg = _resolve_config(cfg)
+    out_dir = Path(rcfg["output_dir"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_resolved_config(rcfg, out_dir / "fft-postprocessed_config.resolved.yml")
+
+    in_csv = Path(rcfg["postprocess_dir"]) / "postprocessed_peak_windows.csv"
+    if not in_csv.exists():
+        raise FileNotFoundError("fft-postprocessed requires postprocessed_peak_windows.csv from postprocess-peak-windows")
+    df = pd.read_csv(in_csv)
+    bins = int(rcfg["fft_bins"])
+    offsets = pd.to_numeric(df.get("first_echo_offset", pd.Series(dtype=float)), errors="coerce").fillna(0).to_numpy(dtype=float)
+    signal = offsets - np.mean(offsets) if offsets.size else np.zeros(1)
+    fft = np.abs(np.fft.rfft(signal, n=bins))
+    np.save(out_dir / "postprocessed_fft.npy", fft.astype(np.float32))
+    pd.DataFrame({"bin": np.arange(len(fft)), "magnitude": fft}).to_csv(out_dir / "postprocessed_fft.csv", index=False)
+    summary = {"n_rows": int(len(df)), "fft_bins": bins, "n_fft_points": int(len(fft))}
+    (out_dir / "fft_postprocessed_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary

--- a/src/echopress/core/peak_window_postprocess.py
+++ b/src/echopress/core/peak_window_postprocess.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+from echopress.core.config_io import merge_config, write_resolved_config
+
+
+@dataclass(frozen=True)
+class PeakWindowPostprocessConfig:
+    echo_dir: Path
+    output_dir: Path
+    config: Optional[Path] = None
+    max_echo_peak_order: Optional[int] = 3
+
+
+def _resolve_config(cfg: PeakWindowPostprocessConfig) -> dict[str, Any]:
+    default_yml = Path(__file__).resolve().parents[3] / "configs" / "peak_window_postprocess.default.yml"
+    rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=cfg.config, cli_values=asdict(cfg))
+    rcfg["echo_dir"] = str(cfg.echo_dir)
+    rcfg["output_dir"] = str(cfg.output_dir)
+    return rcfg
+
+
+def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, Any]:
+    rcfg = _resolve_config(cfg)
+    out_dir = Path(rcfg["output_dir"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_resolved_config(rcfg, out_dir / "postprocess-peak-windows_config.resolved.yml")
+
+    echo_path = Path(rcfg["echo_dir"]) / "echo_peak_index.csv"
+    windows_path = Path(rcfg["echo_dir"]) / "echo_window_index.csv"
+    if not echo_path.exists() or not windows_path.exists():
+        raise FileNotFoundError("postprocess requires echo_peak_index.csv and echo_window_index.csv from detect-echo-peaks")
+    echo = pd.read_csv(echo_path)
+    windows = pd.read_csv(windows_path)
+    if rcfg.get("max_echo_peak_order") is not None and "echo_peak_order" in echo.columns:
+        echo = echo[echo["echo_peak_order"] <= int(rcfg["max_echo_peak_order"])]
+    features = (
+        echo.groupby(["path", "first_peak_idx"], dropna=False)
+        .agg(n_echo_peaks_post=("echo_peak_idx", "count"), first_echo_offset=("echo_peak_offset_from_first_peak", "min"))
+        .reset_index()
+    )
+    merged = windows.merge(features, how="left", on=["path", "first_peak_idx"])
+    merged["n_echo_peaks_post"] = merged["n_echo_peaks_post"].fillna(0).astype(int)
+    merged.to_csv(out_dir / "postprocessed_peak_windows.csv", index=False)
+    summary = {"n_windows": int(len(merged)), "n_echo_peaks": int(len(echo))}
+    (out_dir / "postprocess_peak_windows_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary

--- a/src/echopress/core/qc_plots.py
+++ b/src/echopress/core/qc_plots.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from echopress.core.config_io import write_resolved_config
+
+QCStage = Literal["macro", "echo", "postprocess", "fft"]
+
+
+@dataclass(frozen=True)
+class QCPlotConfig:
+    stage: QCStage
+    input_dir: Path
+    output_dir: Path
+
+
+def run_qc_plot(cfg: QCPlotConfig) -> dict[str, object]:
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+    write_resolved_config({"stage": cfg.stage, "input_dir": str(cfg.input_dir), "output_dir": str(cfg.output_dir)}, cfg.output_dir / f"plot-{cfg.stage}-qc_config.resolved.yml")
+    fig, ax = plt.subplots(figsize=(8, 4))
+    if cfg.stage == "macro":
+        df = pd.read_csv(cfg.input_dir / "first_peak_index.csv")
+        ax.hist(pd.to_numeric(df["first_peak_idx"], errors="coerce").dropna(), bins=50)
+    elif cfg.stage == "echo":
+        df = pd.read_csv(cfg.input_dir / "echo_peak_index.csv")
+        ax.hist(pd.to_numeric(df["echo_peak_offset_from_first_peak"], errors="coerce").dropna(), bins=50)
+    elif cfg.stage == "postprocess":
+        df = pd.read_csv(cfg.input_dir / "postprocessed_peak_windows.csv")
+        ax.hist(pd.to_numeric(df["n_echo_peaks_post"], errors="coerce").dropna(), bins=20)
+    else:
+        arr = np.load(cfg.input_dir / "postprocessed_fft.npy")
+        ax.plot(arr)
+    ax.set_title(f"{cfg.stage} qc")
+    out = cfg.output_dir / f"plot-{cfg.stage}-qc.png"
+    fig.tight_layout()
+    fig.savefig(out)
+    plt.close(fig)
+    summary = {"stage": cfg.stage, "plot": str(out)}
+    (cfg.output_dir / f"plot_{cfg.stage}_qc_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary


### PR DESCRIPTION
### Motivation
- Provide CLI entry points for common post-detection pipeline stages (alignment cleaning, echo-window postprocessing, FFT export and QC plotting) so downstream automation can be run separately.  
- Ensure each stage records the exact resolved configuration to its output directory and that QC commands consume only prior-stage artifacts (no hidden re-detection).  

### Description
- Added new CLI commands in `src/echopress/cli.py`: `clean-align`, `postprocess-peak-windows`, `fft-postprocessed`, `plot-macro-qc`, `plot-echo-qc`, `plot-postprocess-qc`, and `plot-fft-qc`, and wired them to new core modules.  
- Implemented `src/echopress/core/align_cleaner.py` which loads an align table, filters by alignment error and pressure bounds, writes `align.cleaned.json` and a summary, and writes a resolved config YAML (`clean-align_config.resolved.yml`).  
- Implemented `src/echopress/core/peak_window_postprocess.py` which reads `echo_peak_index.csv` and `echo_window_index.csv`, computes per-window aggregated features, writes `postprocessed_peak_windows.csv` plus a summary, and writes a resolved config YAML (`postprocess-peak-windows_config.resolved.yml`).  
- Implemented `src/echopress/core/fft_export.py` which reads `postprocessed_peak_windows.csv`, computes an FFT of the chosen feature, writes `postprocessed_fft.npy`/CSV and a summary, and writes a resolved config YAML (`fft-postprocessed_config.resolved.yml`).  
- Implemented `src/echopress/core/qc_plots.py` which reads stage-specific artifacts only (macro: `first_peak_index.csv`, echo: `echo_peak_index.csv`, postprocess: `postprocessed_peak_windows.csv`, fft: `postprocessed_fft.npy`), produces a PNG QC plot and a summary, and writes a resolved config YAML (`plot-<stage>-qc_config.resolved.yml`).  

### Testing
- Ran Python byte-compile on the new modules with `python -m py_compile src/echopress/cli.py src/echopress/core/align_cleaner.py src/echopress/core/peak_window_postprocess.py src/echopress/core/fft_export.py src/echopress/core/qc_plots.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1399ae3c2083228d2f5029e085c6f0)