### PR TITLE
Add selected_files manifest and peak-to-peak window index export

### DIFF
--- a/src/echopress/core/macro_detector.py
+++ b/src/echopress/core/macro_detector.py
@@ -189,6 +189,33 @@ def _resolve_config(cfg: MacroDetectorConfig) -> dict[str, object]:
     resolved["output_dir"] = str(Path(cfg.output_dir))
     return resolved
 
+
+def build_peak_to_peak_window_index(first_peak_df: pd.DataFrame, t_global_samples: float) -> pd.DataFrame:
+    rows = []
+    for _, grp in first_peak_df.groupby("path"):
+        g = grp.sort_values("first_peak_idx").reset_index(drop=True)
+        for i in range(len(g) - 1):
+            start_peak = int(g.iloc[i]["first_peak_idx"])
+            end_peak = int(g.iloc[i + 1]["first_peak_idx"])
+            rows.append(
+                {
+                    "path": g.iloc[i]["path"],
+                    "file": g.iloc[i]["file"],
+                    "pressure_value": g.iloc[i]["pressure_value"],
+                    "file_index": int(g.iloc[i]["file_index"]),
+                    "peak_to_peak_window_index": i,
+                    "start_first_peak_idx": start_peak,
+                    "end_first_peak_idx": end_peak,
+                    "window_len_samples": int(end_peak - start_peak),
+                    "T_global_samples": float(t_global_samples),
+                    "used_for_common_peak_to_peak_window": bool(
+                        bool(g.iloc[i].get("used_for_backward_common_window", False))
+                        and bool(g.iloc[i + 1].get("used_for_backward_common_window", False))
+                    ),
+                }
+            )
+    return pd.DataFrame(rows)
+
 def run_macro_detection(cfg: MacroDetectorConfig) -> dict:
     rcfg = _resolve_config(cfg)
     cfg = MacroDetectorConfig(
@@ -204,6 +231,7 @@ def run_macro_detection(cfg: MacroDetectorConfig) -> dict:
     diag_dir.mkdir(exist_ok=True)
     align = load_alignment_rows(cfg)
     align.to_csv(out / "alignment_filtered.csv", index=False)
+    align[["path", "file"]].to_csv(out / "selected_files.csv", index=False)
 
     if not cfg.quiet:
         ae = align["alignment_error"] if "alignment_error" in align.columns else None
@@ -374,6 +402,9 @@ def run_macro_detection(cfg: MacroDetectorConfig) -> dict:
     reg_df = pd.concat(final, ignore_index=True) if final else reg_df
     reg_df.to_csv(out / "first_peak_index.registered.csv", index=False)
     counts_df.to_csv(out / "backward_full_window_counts.csv", index=False)
+
+    p2p_df = build_peak_to_peak_window_index(first_df, T_global)
+    p2p_df.to_csv(out / "peak_to_peak_window_index.csv", index=False)
 
     if cfg.write_signatures:
         sig_rows = reg_df[reg_df.get("used_for_backward_common_window", False)].copy()

--- a/tests/test_macro_peak_to_peak_index.py
+++ b/tests/test_macro_peak_to_peak_index.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from echopress.core.macro_detector import build_peak_to_peak_window_index
+
+
+def test_build_peak_to_peak_window_index_yields_four_windows_per_file_for_five_peaks():
+    rows = []
+    for file_index, file_name in enumerate(("f1.npz", "f2.npz")):
+        for peak_idx in (100, 200, 300, 400, 500):
+            rows.append(
+                {
+                    "path": f"/tmp/{file_name}",
+                    "file": file_name,
+                    "pressure_value": 10.0 + file_index,
+                    "file_index": file_index,
+                    "first_peak_idx": peak_idx,
+                }
+            )
+
+    first_peak_df = pd.DataFrame(rows)
+
+    p2p_df = build_peak_to_peak_window_index(first_peak_df, t_global_samples=100.0)
+
+    per_file = p2p_df.groupby("path").size().to_dict()
+    assert per_file == {"/tmp/f1.npz": 4, "/tmp/f2.npz": 4}
+    assert (p2p_df["window_len_samples"] == 100).all()


### PR DESCRIPTION
### Motivation
- Provide a stable file-key manifest after alignment filtering for downstream consumers by writing a `selected_files.csv` containing `path` and `file`. 
- Derive peak-to-peak windows from discovered first peaks (grouped per file, ordered by `first_peak_idx`) so downstream processing can operate on consecutive peak pairs with explicit window metadata.

### Description
- Add `build_peak_to_peak_window_index(first_peak_df, t_global_samples)` which iterates per-file sorted `first_peak_idx` and emits one row per consecutive peak pair containing `path, file, pressure_value, file_index, peak_to_peak_window_index, start_first_peak_idx, end_first_peak_idx, window_len_samples, T_global_samples, used_for_common_peak_to_peak_window`.
- Write the filtered alignment manifest to `selected_files.csv` (columns `path` and `file`) immediately after `load_alignment_rows` is applied.
- Generate and persist `peak_to_peak_window_index.csv` by invoking the new helper with `first_df` and the computed `T_global` inside `run_macro_detection`.
- Add targeted unit test `tests/test_macro_peak_to_peak_index.py` that constructs two files each with five first peaks and asserts that `build_peak_to_peak_window_index` returns four peak-to-peak windows per file and correct `window_len_samples`.

### Testing
- Ran `pytest -q tests/test_macro_peak_to_peak_index.py` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a139c0cafa083229da4ba00f8d1bbe8)