### PR TITLE
Add standalone FFT-based pressure regression baseline pipeline

### DIFF
--- a/configs/pressure_regression.default.yml
+++ b/configs/pressure_regression.default.yml
@@ -1,0 +1,36 @@
+dataset:
+  feature_source: fft_relative_db
+  target_column: pressure_value
+  freq_min_cycles_per_window: 0.5
+  freq_max_cycles_per_window: 200.0
+  bin_average: 4
+  require_finite: true
+  drop_nan_targets: true
+split:
+  method: pressure_stratified
+  train_frac: 0.70
+  val_frac: 0.15
+  test_frac: 0.15
+  pressure_bins: 10
+  random_seed: 42
+preprocess:
+  x_scaler: standard
+  y_scaler: standard
+model:
+  architecture: fft_mlp
+  hidden_units: [256, 128, 64]
+  dropout: 0.10
+  batch_norm: true
+  output_activation: linear
+train:
+  epochs: 300
+  batch_size: 32
+  learning_rate: 0.001
+  loss: mse
+  early_stopping_patience: 30
+  reduce_lr_patience: 12
+  reduce_lr_factor: 0.5
+  min_lr: 0.000001
+  monitor: val_loss
+  random_seed: 42
+  verbose: 1

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,0 +1,3 @@
+tensorflow>=2.16
+scikit-learn>=1.4
+PyYAML>=6.0

--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -28,6 +28,9 @@ from .core.qc_plots import QCPlotConfig, run_qc_plot
 from .core.rmcpe import RMCPEConfig, run_rmcpe
 from .core.tables import File2PressureMap, OscFiles, Signals, export_tables
 from .core.tciml import TCIMLConfig, run_tciml
+from .ml.dataset import PressureDatasetConfig, build_pressure_dataset
+from .ml.train import PressureTrainConfig, run_train
+from .ml.evaluate import PressureEvalConfig, run_evaluate
 from .config import Settings, load_settings
 from .ingest import DatasetIndexer, load_ostream, read_pstream
 from ._typer import bad_parameter
@@ -1099,6 +1102,38 @@ def adapt(
         return None
 
     return outputs
+
+
+@app.command("build-pressure-regression-dataset")
+def build_pressure_regression_dataset(
+    fft_dir: Path = typer.Option(..., "--fft-dir", file_okay=False, dir_okay=True),
+    output_dir: Path = typer.Option(..., "--output-dir", file_okay=False, dir_okay=True),
+    config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+) -> None:
+    summary = build_pressure_dataset(
+        PressureDatasetConfig(fft_dir=fft_dir, output_dir=output_dir, config=config)
+    )
+    typer.echo(json.dumps(summary, indent=2))
+
+
+@app.command("train-pressure-regressor")
+def train_pressure_regressor(
+    dataset_dir: Path = typer.Option(..., "--dataset-dir", file_okay=False, dir_okay=True),
+    output_dir: Path = typer.Option(..., "--output-dir", file_okay=False, dir_okay=True),
+    config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+) -> None:
+    run_train(PressureTrainConfig(dataset_dir=dataset_dir, output_dir=output_dir, config=config))
+    typer.echo(json.dumps({"status": "ok", "output_dir": str(output_dir)}, indent=2))
+
+
+@app.command("eval-pressure-regressor")
+def eval_pressure_regressor(
+    dataset_dir: Path = typer.Option(..., "--dataset-dir", file_okay=False, dir_okay=True),
+    model_dir: Path = typer.Option(..., "--model-dir", file_okay=False, dir_okay=True),
+    split: str = typer.Option("test", "--split"),
+) -> None:
+    run_evaluate(PressureEvalConfig(dataset_dir=dataset_dir, model_dir=model_dir, split=split))
+    typer.echo(json.dumps({"status": "ok", "model_dir": str(model_dir), "split": split}, indent=2))
 
 
 @app.command()

--- a/src/echopress/ml/__init__.py
+++ b/src/echopress/ml/__init__.py
@@ -1,0 +1,1 @@
+"""ML baseline pipeline for pressure regression."""

--- a/src/echopress/ml/dataset.py
+++ b/src/echopress/ml/dataset.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+import numpy as np
+import pandas as pd
+from echopress.core.config_io import merge_config, write_resolved_config
+from .splits import make_pressure_splits
+
+@dataclass(frozen=True)
+class PressureDatasetConfig:
+    fft_dir: Path
+    output_dir: Path
+    config: Optional[Path] = None
+    feature_source: Optional[str] = None
+    target_column: Optional[str] = None
+    freq_min_cycles_per_window: Optional[float] = None
+    freq_max_cycles_per_window: Optional[float] = None
+    bin_average: Optional[int] = None
+    require_finite: Optional[bool] = None
+    drop_nan_targets: Optional[bool] = None
+
+def _resolve_config(cfg: PressureDatasetConfig) -> dict[str, Any]:
+    default_yml = Path(__file__).resolve().parents[3] / "configs" / "pressure_regression.default.yml"
+    rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=cfg.config, cli_values=asdict(cfg))
+    for k in ("feature_source","target_column","freq_min_cycles_per_window","freq_max_cycles_per_window","bin_average","require_finite","drop_nan_targets"):
+        if k in rcfg.get("dataset", {}) and rcfg.get(k) is None:
+            rcfg[k] = rcfg["dataset"][k]
+    rcfg["fft_dir"] = str(cfg.fft_dir); rcfg["output_dir"] = str(cfg.output_dir)
+    return rcfg
+
+def build_pressure_dataset(cfg: PressureDatasetConfig) -> dict[str, Any]:
+    rcfg = _resolve_config(cfg)
+    out = Path(rcfg["output_dir"]); out.mkdir(parents=True, exist_ok=True)
+    write_resolved_config(rcfg, out / "dataset_config.resolved.yml")
+    fft_dir = Path(rcfg["fft_dir"])
+    manifest = pd.read_csv(fft_dir / "fft_manifest.csv")
+    target = rcfg.get("target_column", "pressure_value")
+    y = pd.to_numeric(manifest[target], errors="coerce").to_numpy(dtype=float)
+    if rcfg.get("drop_nan_targets", True):
+        keep = np.isfinite(y)
+        manifest = manifest.loc[keep].reset_index(drop=True); y = y[keep]
+    src = str(rcfg.get("feature_source", "fft_relative_db"))
+    name = {"fft_relative_db":"fft_relative_db.npy","fft-relative-db":"fft_relative_db.npy","fft_db":"fft_db.npy","fft-db":"fft_db.npy","fft_mag":"fft_magnitude.npy","fft-mag":"fft_magnitude.npy"}.get(src, "fft_relative_db.npy")
+    x_all = np.load(fft_dir / name)
+    if len(x_all) != len(pd.read_csv(fft_dir / "fft_manifest.csv")):
+        raise ValueError("feature rows do not match fft_manifest.csv")
+    if rcfg.get("drop_nan_targets", True): x_all = x_all[keep]
+    freq = np.load(fft_dir / "fft_cycles_per_window.npy")
+    m = (freq >= float(rcfg.get("freq_min_cycles_per_window",0.0))) & (freq <= float(rcfg.get("freq_max_cycles_per_window", np.max(freq))))
+    X = x_all[:, m]; f = freq[m]
+    b = int(rcfg.get("bin_average",1) or 1)
+    if b > 1:
+        n = (X.shape[1] // b) * b
+        X = X[:, :n].reshape(X.shape[0], -1, b).mean(axis=2)
+        f = f[:n].reshape(-1,b).mean(axis=1)
+    if rcfg.get("require_finite", True):
+        good = np.isfinite(X).all(axis=1) & np.isfinite(y)
+        X = X[good]; y = y[good]; manifest = manifest.loc[good].reset_index(drop=True)
+    splits = make_pressure_splits(y, manifest, rcfg.get("split", {}))
+    split_map = np.array(["train"] * len(y), dtype=object)
+    split_map[splits["val"]] = "val"; split_map[splits["test"]] = "test"
+    manifest = manifest.copy(); manifest["row"] = np.arange(len(manifest)); manifest["split"] = split_map
+    cols = [c for c in ["row","path","file","pressure_value","split"] if c in manifest.columns]
+    manifest[cols].to_csv(out / "sample_manifest.csv", index=False)
+    np.save(out / "X.npy", X.astype(np.float32)); np.save(out / "y.npy", y.astype(np.float32)); np.save(out / "feature_axis.npy", f.astype(np.float32))
+    (out / "split.json").write_text(json.dumps(splits, indent=2), encoding="utf-8")
+    summary = {"n_samples": int(len(y)), "n_features": int(X.shape[1]), "feature_source": src}
+    (out / "dataset_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary

--- a/src/echopress/ml/evaluate.py
+++ b/src/echopress/ml/evaluate.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+import numpy as np, pandas as pd
+
+@dataclass(frozen=True)
+class PressureEvalConfig:
+    dataset_dir: Path
+    model_dir: Path
+    split: str = "test"
+
+def run_evaluate(cfg: PressureEvalConfig):
+    import matplotlib.pyplot as plt
+    import tensorflow as tf
+    ds=Path(cfg.dataset_dir); md=Path(cfg.model_dir); out=md/f"eval_{cfg.split}"; out.mkdir(parents=True, exist_ok=True)
+    X=np.load(ds/"X.npy"); y=np.load(ds/"y.npy"); split=json.loads((ds/"split.json").read_text())
+    idx=np.array(split[cfg.split]); prep=json.loads((md/"preprocessing.json").read_text())
+    Xs=(X[idx]-np.array(prep["x_mean"])) / np.array(prep["x_std"])
+    model=tf.keras.models.load_model(md/"model_best.keras")
+    pred=(model.predict(Xs, verbose=0).reshape(-1)*prep["y_std"]+prep["y_mean"])
+    yt=y[idx]; resid=pred-yt
+    mae=float(np.mean(np.abs(resid))); rmse=float(np.sqrt(np.mean(resid**2))); bias=float(np.mean(resid)); med=float(np.median(np.abs(resid))); mmax=float(np.max(np.abs(resid))); r2=float(1.0 - np.sum(resid**2)/max(np.sum((yt-np.mean(yt))**2),1e-12))
+    (out/"metrics_test.json").write_text(json.dumps({"mae":mae,"rmse":rmse,"r2":r2,"bias":bias,"median_abs_error":med,"max_abs_error":mmax,"n_test":int(len(idx))}, indent=2), encoding="utf-8")
+    pd.DataFrame({"y_true":yt,"y_pred":pred,"residual":resid}).to_csv(out/"predictions_test.csv", index=False)
+    plt.figure(); plt.scatter(yt,pred,s=10); plt.xlabel("true"); plt.ylabel("pred"); plt.tight_layout(); plt.savefig(out/"prediction_vs_true.png", dpi=170); plt.close()

--- a/src/echopress/ml/models.py
+++ b/src/echopress/ml/models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+def build_model(n_features, cfg):
+    try:
+        import tensorflow as tf
+    except ImportError as exc:
+        raise RuntimeError("TensorFlow is required. Install with: pip install -r requirements-ml.txt") from exc
+    mcfg = cfg.get("model", {})
+    units = mcfg.get("hidden_units", [256,128,64]); dropout=float(mcfg.get("dropout",0.1)); batch_norm=bool(mcfg.get("batch_norm",True))
+    inp = tf.keras.Input(shape=(n_features,))
+    x = inp
+    for i,u in enumerate(units):
+        x = tf.keras.layers.Dense(int(u))(x)
+        if batch_norm and i < 2: x = tf.keras.layers.BatchNormalization()(x)
+        x = tf.keras.layers.ReLU()(x)
+        if i < 2 and dropout>0: x = tf.keras.layers.Dropout(dropout)(x)
+    out = tf.keras.layers.Dense(1, activation=mcfg.get("output_activation","linear"))(x)
+    model = tf.keras.Model(inp, out)
+    return model

--- a/src/echopress/ml/preprocess.py
+++ b/src/echopress/ml/preprocess.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+import json
+import numpy as np
+
+def fit_transform_preprocess(X_train, X_val, X_test, y_train, y_val, y_test, cfg, out_path):
+    x_mu = X_train.mean(axis=0); x_sd = X_train.std(axis=0); x_sd[x_sd==0]=1.0
+    y_mu = float(np.mean(y_train)); y_sd=float(np.std(y_train) or 1.0)
+    X_train=(X_train-x_mu)/x_sd; X_val=(X_val-x_mu)/x_sd; X_test=(X_test-x_mu)/x_sd
+    y_train_s=(y_train-y_mu)/y_sd; y_val_s=(y_val-y_mu)/y_sd; y_test_s=(y_test-y_mu)/y_sd
+    obj={"x_scaler":"standard","y_scaler":"standard","x_mean":x_mu.tolist(),"x_std":x_sd.tolist(),"y_mean":y_mu,"y_std":y_sd}
+    out_path.write_text(json.dumps(obj, indent=2), encoding="utf-8")
+    return X_train, X_val, X_test, y_train_s, y_val_s, y_test_s, obj

--- a/src/echopress/ml/splits.py
+++ b/src/echopress/ml/splits.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+import numpy as np, pandas as pd
+
+def make_pressure_splits(y, manifest, cfg):
+    train_frac = float(cfg.get("train_frac",0.70)); val_frac=float(cfg.get("val_frac",0.15));
+    n = len(y); rng = np.random.default_rng(int(cfg.get("random_seed",42)))
+    idx = np.arange(n)
+    method = cfg.get("method","pressure_stratified")
+    train=[]; val=[]; test=[]
+    if method == "pressure_stratified":
+        q = int(cfg.get("pressure_bins",10))
+        bins = pd.qcut(pd.Series(y), q=min(q, len(np.unique(y))), duplicates="drop")
+        for _, g in pd.Series(idx).groupby(bins):
+            a = g.to_numpy(); rng.shuffle(a); ntr=int(round(len(a)*train_frac)); nv=int(round(len(a)*val_frac))
+            train.extend(a[:ntr]); val.extend(a[ntr:ntr+nv]); test.extend(a[ntr+nv:])
+    else:
+        a = idx.copy(); rng.shuffle(a); ntr=int(round(n*train_frac)); nv=int(round(n*val_frac))
+        train=a[:ntr].tolist(); val=a[ntr:ntr+nv].tolist(); test=a[ntr+nv:].tolist()
+    return {"train": sorted(map(int,train)), "val": sorted(map(int,val)), "test": sorted(map(int,test)), "method": method, "random_seed": int(cfg.get("random_seed",42))}

--- a/src/echopress/ml/train.py
+++ b/src/echopress/ml/train.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+import numpy as np, pandas as pd
+from echopress.core.config_io import merge_config, write_resolved_config
+from .models import build_model
+from .preprocess import fit_transform_preprocess
+
+@dataclass(frozen=True)
+class PressureTrainConfig:
+    dataset_dir: Path
+    output_dir: Path
+    config: Optional[Path] = None
+
+def run_train(cfg: PressureTrainConfig):
+    try:
+        import tensorflow as tf
+    except ImportError as exc:
+        raise RuntimeError("TensorFlow is required. Install with: pip install -r requirements-ml.txt") from exc
+    default_yml = Path(__file__).resolve().parents[3] / "configs" / "pressure_regression.default.yml"
+    rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=cfg.config, cli_values={"dataset_dir":str(cfg.dataset_dir),"output_dir":str(cfg.output_dir)})
+    out=Path(cfg.output_dir); out.mkdir(parents=True, exist_ok=True); write_resolved_config(rcfg, out/"train_config.resolved.yml")
+    X=np.load(Path(cfg.dataset_dir)/"X.npy"); y=np.load(Path(cfg.dataset_dir)/"y.npy"); split=json.loads((Path(cfg.dataset_dir)/"split.json").read_text())
+    tr,va,te=np.array(split["train"]),np.array(split["val"]),np.array(split["test"])
+    Xtr,Xva,Xte, ytr,yva,yte, prep = fit_transform_preprocess(X[tr],X[va],X[te],y[tr],y[va],y[te], rcfg.get("preprocess",{}), out/"preprocessing.json")
+    model=build_model(X.shape[1], rcfg)
+    tcfg=rcfg.get("train",{})
+    model.compile(optimizer=tf.keras.optimizers.Adam(float(tcfg.get("learning_rate",1e-3))), loss=tcfg.get("loss","mse"), metrics=["mae", tf.keras.metrics.RootMeanSquaredError(name="rmse")])
+    cb=[tf.keras.callbacks.EarlyStopping(monitor=tcfg.get("monitor","val_loss"), patience=int(tcfg.get("early_stopping_patience",30)), restore_best_weights=True), tf.keras.callbacks.ModelCheckpoint(filepath=str(out/"model_best.keras"), monitor=tcfg.get("monitor","val_loss"), save_best_only=True), tf.keras.callbacks.ReduceLROnPlateau(monitor=tcfg.get("monitor","val_loss"), patience=int(tcfg.get("reduce_lr_patience",12)), factor=float(tcfg.get("reduce_lr_factor",0.5)), min_lr=float(tcfg.get("min_lr",1e-6)))]
+    h=model.fit(Xtr,ytr,validation_data=(Xva,yva),epochs=int(tcfg.get("epochs",300)),batch_size=int(tcfg.get("batch_size",32)),verbose=int(tcfg.get("verbose",1)),callbacks=cb)
+    model.save(out/"model.keras")
+    pd.DataFrame(h.history).to_csv(out/"history.csv", index=False)
+    val_pred = model.predict(Xva, verbose=0).reshape(-1) * prep["y_std"] + prep["y_mean"]
+    y_true = y[va]
+    mae=float(np.mean(np.abs(val_pred-y_true))); rmse=float(np.sqrt(np.mean((val_pred-y_true)**2)))
+    (out/"metrics_val.json").write_text(json.dumps({"mae":mae,"rmse":rmse,"n_val":int(len(va))}, indent=2), encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a separate `src/echopress/ml/` package for a durable ML baseline pipeline
- implement dataset building from stored FFT outputs with feature slicing/bin-averaging and pressure-stratified splits
- implement TensorFlow MLP training with preprocessing persistence and best-checkpoint saving
- implement evaluation that emits metrics, predictions CSV, and prediction-vs-true plot
- add CLI commands:
  - `build-pressure-regression-dataset`
  - `train-pressure-regressor`
  - `eval-pressure-regressor`
- add baseline defaults at `configs/pressure_regression.default.yml`
- add optional ML deps in `requirements-ml.txt`

## Notes
- ML functionality is isolated from macro/echo/FFT detection stages and consumes stored artifacts.
- TensorFlow remains optional for the main repo and is required only when running ML commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1477f63be0832288223aec58b34cee)