### PR TITLE
Add echopress.ml pipeline package with dataset/split/preprocess/model/train/eval stages

### DIFF
--- a/src/echopress/ml/__init__.py
+++ b/src/echopress/ml/__init__.py
@@ -1,0 +1,24 @@
+"""Machine-learning pipeline helpers for echopress."""
+
+from .dataset import build_dataset, DatasetBuildConfig
+from .splits import build_split, SplitConfig
+from .preprocess import fit_preprocessing, transform_with_preprocessing, PreprocessConfig
+from .models import build_model, ModelConfig
+from .train import train_model, TrainConfig
+from .evaluate import evaluate_model, EvaluateConfig
+
+__all__ = [
+    "DatasetBuildConfig",
+    "SplitConfig",
+    "PreprocessConfig",
+    "ModelConfig",
+    "TrainConfig",
+    "EvaluateConfig",
+    "build_dataset",
+    "build_split",
+    "fit_preprocessing",
+    "transform_with_preprocessing",
+    "build_model",
+    "train_model",
+    "evaluate_model",
+]

--- a/src/echopress/ml/dataset.py
+++ b/src/echopress/ml/dataset.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel, ConfigDict, Field
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+class DatasetBuildConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    fft_glob: str = "**/*fft*.npz"
+    feature_key: str = "features"
+    target_key: str = "pressure"
+    axis_key: str = "feature_axis"
+    output_dir: Path = Path("ml/dataset")
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    if yaml is not None:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+        return
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def build_dataset(artifact_root: Path, config: DatasetBuildConfig) -> dict[str, Any]:
+    out_dir = Path(config.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, Any]] = []
+    x_parts: list[np.ndarray] = []
+    y_parts: list[np.ndarray] = []
+    feature_axis: np.ndarray | None = None
+
+    for artifact in sorted(Path(artifact_root).glob(config.fft_glob)):
+        with np.load(artifact, allow_pickle=True) as obj:
+            if config.feature_key not in obj or config.target_key not in obj:
+                continue
+            feats = np.asarray(obj[config.feature_key], dtype=np.float32)
+            target = np.asarray(obj[config.target_key], dtype=np.float32).reshape(-1)
+            if feats.ndim == 1:
+                feats = feats.reshape(1, -1)
+            if feats.shape[0] != target.shape[0]:
+                raise ValueError(f"Feature/target length mismatch for {artifact}")
+            if feature_axis is None and config.axis_key in obj:
+                feature_axis = np.asarray(obj[config.axis_key])
+
+            x_parts.append(feats)
+            y_parts.append(target)
+            for i in range(feats.shape[0]):
+                rows.append({
+                    "sample_index": len(rows),
+                    "source_file": str(artifact),
+                    "source_row": int(i),
+                    "pressure": float(target[i]),
+                })
+
+    if not x_parts:
+        raise FileNotFoundError(f"No FFT artifacts matched {config.fft_glob} under {artifact_root}")
+
+    x = np.concatenate(x_parts, axis=0)
+    y = np.concatenate(y_parts, axis=0)
+    if feature_axis is None:
+        feature_axis = np.arange(x.shape[1], dtype=np.int64)
+
+    np.save(out_dir / "X.npy", x)
+    np.save(out_dir / "y.npy", y)
+    np.save(out_dir / "feature_axis.npy", feature_axis)
+    pd.DataFrame(rows).to_csv(out_dir / "sample_manifest.csv", index=False)
+
+    summary = {
+        "num_samples": int(x.shape[0]),
+        "num_features": int(x.shape[1]),
+        "target_mean": float(y.mean()),
+        "target_std": float(y.std()),
+        "source_artifacts": int(len(x_parts)),
+    }
+    (out_dir / "dataset_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    _write_yaml(out_dir / "dataset_config.resolved.yaml", config.model_dump(mode="json"))
+    return summary

--- a/src/echopress/ml/evaluate.py
+++ b/src/echopress/ml/evaluate.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel, ConfigDict
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+class EvaluateConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    batch_size: int = 256
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    if yaml is not None:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def evaluate_model(model, X_test: np.ndarray, y_test: np.ndarray, output_dir: Path, config: EvaluateConfig) -> dict[str, float]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    preds = model.predict(X_test, batch_size=config.batch_size, verbose=0).reshape(-1)
+    residuals = y_test - preds
+
+    mse = float(np.mean((residuals) ** 2))
+    rmse = float(np.sqrt(mse))
+    mae = float(np.mean(np.abs(residuals)))
+    r2 = float(1.0 - np.sum(residuals**2) / np.sum((y_test - y_test.mean()) ** 2))
+
+    metrics = {"mse": mse, "rmse": rmse, "mae": mae, "r2": r2}
+    (output_dir / "test_metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+
+    pd.DataFrame({"y_true": y_test, "y_pred": preds, "residual": residuals}).to_csv(
+        output_dir / "predictions.csv", index=False
+    )
+
+    fig, ax = plt.subplots(figsize=(7, 5))
+    ax.scatter(y_test, preds, s=10, alpha=0.6)
+    lo = min(float(y_test.min()), float(preds.min()))
+    hi = max(float(y_test.max()), float(preds.max()))
+    ax.plot([lo, hi], [lo, hi], linestyle="--")
+    ax.set_xlabel("True pressure")
+    ax.set_ylabel("Predicted pressure")
+    fig.tight_layout()
+    fig.savefig(output_dir / "prediction_scatter.png", dpi=150)
+    plt.close(fig)
+
+    fig, ax = plt.subplots(figsize=(7, 5))
+    ax.hist(residuals, bins=40)
+    ax.set_xlabel("Residual (true - pred)")
+    ax.set_ylabel("Count")
+    fig.tight_layout()
+    fig.savefig(output_dir / "residual_hist.png", dpi=150)
+    plt.close(fig)
+
+    _write_yaml(output_dir / "evaluate_config.resolved.yaml", config.model_dump(mode="json"))
+    return metrics

--- a/src/echopress/ml/models.py
+++ b/src/echopress/ml/models.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    model_name: str = "fft_mlp"
+    hidden_dims: list[int] = Field(default_factory=lambda: [256, 128, 64])
+    dropout: float = 0.2
+    learning_rate: float = 1e-3
+
+
+def build_model(input_dim: int, config: ModelConfig):
+    try:
+        import tensorflow as tf
+    except Exception as exc:  # pragma: no cover - dependency/runtime guard
+        raise RuntimeError("TensorFlow is required for model building") from exc
+
+    if config.model_name != "fft_mlp":
+        raise ValueError(f"Unsupported model: {config.model_name}")
+
+    inputs = tf.keras.Input(shape=(input_dim,), name="fft_features")
+    x = inputs
+    for i, width in enumerate(config.hidden_dims):
+        x = tf.keras.layers.Dense(width, activation="relu", name=f"dense_{i}")(x)
+        if config.dropout > 0:
+            x = tf.keras.layers.Dropout(config.dropout, name=f"dropout_{i}")(x)
+    outputs = tf.keras.layers.Dense(1, activation="linear", name="pressure")(x)
+    model = tf.keras.Model(inputs=inputs, outputs=outputs, name=config.model_name)
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(learning_rate=config.learning_rate),
+        loss="mse",
+        metrics=[tf.keras.metrics.MeanAbsoluteError(name="mae")],
+    )
+    return model

--- a/src/echopress/ml/preprocess.py
+++ b/src/echopress/ml/preprocess.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+class PreprocessConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scale_x: bool = True
+    scale_y: bool = True
+    eps: float = 1e-8
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    if yaml is not None:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def fit_preprocessing(X_train: np.ndarray, y_train: np.ndarray, output_dir: Path, config: PreprocessConfig) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    x_mean = X_train.mean(axis=0) if config.scale_x else np.zeros(X_train.shape[1], dtype=np.float32)
+    x_std = X_train.std(axis=0) if config.scale_x else np.ones(X_train.shape[1], dtype=np.float32)
+    x_std = np.where(x_std < config.eps, 1.0, x_std)
+
+    y_mean = float(y_train.mean()) if config.scale_y else 0.0
+    y_std = float(y_train.std()) if config.scale_y else 1.0
+    if y_std < config.eps:
+        y_std = 1.0
+
+    payload = {
+        "x_mean": x_mean.tolist(),
+        "x_std": x_std.tolist(),
+        "y_mean": y_mean,
+        "y_std": y_std,
+        "scale_x": config.scale_x,
+        "scale_y": config.scale_y,
+    }
+    (output_dir / "preprocessing.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    _write_yaml(output_dir / "preprocess_config.resolved.yaml", config.model_dump(mode="json"))
+    return payload
+
+
+def transform_with_preprocessing(X: np.ndarray, y: np.ndarray | None, preprocessing: dict[str, Any]) -> tuple[np.ndarray, np.ndarray | None]:
+    X_out = X
+    y_out = y
+    if preprocessing.get("scale_x", True):
+        x_mean = np.asarray(preprocessing["x_mean"], dtype=np.float32)
+        x_std = np.asarray(preprocessing["x_std"], dtype=np.float32)
+        X_out = (X_out - x_mean) / x_std
+    if y_out is not None and preprocessing.get("scale_y", True):
+        y_out = (y_out - float(preprocessing["y_mean"])) / float(preprocessing["y_std"])
+    return X_out, y_out

--- a/src/echopress/ml/splits.py
+++ b/src/echopress/ml/splits.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+class SplitConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    method: str = "pressure_stratified"
+    train_ratio: float = 0.7
+    val_ratio: float = 0.15
+    test_ratio: float = 0.15
+    random_seed: int = 7
+    bins: int = 10
+    holdout_min_pressure: float | None = None
+    holdout_max_pressure: float | None = None
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    if yaml is not None:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _partition_indices(idxs: np.ndarray, cfg: SplitConfig) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    n = len(idxs)
+    n_train = int(round(n * cfg.train_ratio))
+    n_val = int(round(n * cfg.val_ratio))
+    n_train = min(n_train, n)
+    n_val = min(n_val, n - n_train)
+    train = idxs[:n_train]
+    val = idxs[n_train : n_train + n_val]
+    test = idxs[n_train + n_val :]
+    return train, val, test
+
+
+def build_split(y: np.ndarray, output_dir: Path, config: SplitConfig) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(config.random_seed)
+    indices = np.arange(len(y))
+
+    if config.method == "random":
+        shuffled = indices.copy()
+        rng.shuffle(shuffled)
+        train, val, test = _partition_indices(shuffled, config)
+    elif config.method == "holdout":
+        if config.holdout_min_pressure is None or config.holdout_max_pressure is None:
+            raise ValueError("holdout_min_pressure and holdout_max_pressure are required for holdout method")
+        mask = (y >= config.holdout_min_pressure) & (y <= config.holdout_max_pressure)
+        test = indices[mask]
+        remainder = indices[~mask]
+        rng.shuffle(remainder)
+        train, val, _ = _partition_indices(remainder, config)
+    else:
+        quantiles = np.quantile(y, np.linspace(0.0, 1.0, config.bins + 1))
+        train_parts: list[np.ndarray] = []
+        val_parts: list[np.ndarray] = []
+        test_parts: list[np.ndarray] = []
+        for i in range(config.bins):
+            lo, hi = quantiles[i], quantiles[i + 1]
+            if i == config.bins - 1:
+                bucket = indices[(y >= lo) & (y <= hi)]
+            else:
+                bucket = indices[(y >= lo) & (y < hi)]
+            rng.shuffle(bucket)
+            b_train, b_val, b_test = _partition_indices(bucket, config)
+            train_parts.append(b_train)
+            val_parts.append(b_val)
+            test_parts.append(b_test)
+        train = np.concatenate(train_parts)
+        val = np.concatenate(val_parts)
+        test = np.concatenate(test_parts)
+        rng.shuffle(train)
+        rng.shuffle(val)
+        rng.shuffle(test)
+
+    payload = {
+        "train": train.tolist(),
+        "val": val.tolist(),
+        "test": test.tolist(),
+        "sizes": {"train": len(train), "val": len(val), "test": len(test)},
+    }
+    (output_dir / "split.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    _write_yaml(output_dir / "split_config.resolved.yaml", config.model_dump(mode="json"))
+    return payload

--- a/src/echopress/ml/train.py
+++ b/src/echopress/ml/train.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict
+
+from .models import ModelConfig, build_model
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+class TrainConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    batch_size: int = 64
+    epochs: int = 100
+    early_stopping_patience: int = 10
+    reduce_lr_patience: int = 5
+    model: ModelConfig = ModelConfig()
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    if yaml is not None:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def train_model(
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_val: np.ndarray,
+    y_val: np.ndarray,
+    output_dir: Path,
+    config: TrainConfig,
+):
+    try:
+        import tensorflow as tf
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError("TensorFlow is required for training") from exc
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model = build_model(X_train.shape[1], config.model)
+
+    callbacks = [
+        tf.keras.callbacks.EarlyStopping(
+            monitor="val_loss", patience=config.early_stopping_patience, restore_best_weights=True
+        ),
+        tf.keras.callbacks.ReduceLROnPlateau(monitor="val_loss", patience=config.reduce_lr_patience),
+    ]
+    history = model.fit(
+        X_train,
+        y_train,
+        validation_data=(X_val, y_val),
+        batch_size=config.batch_size,
+        epochs=config.epochs,
+        callbacks=callbacks,
+        verbose=2,
+    )
+
+    hist_payload = {k: [float(vv) for vv in v] for k, v in history.history.items()}
+    (output_dir / "history.json").write_text(json.dumps(hist_payload, indent=2), encoding="utf-8")
+
+    val_metrics = model.evaluate(X_val, y_val, verbose=0, return_dict=True)
+    metrics_payload = {k: float(v) for k, v in val_metrics.items()}
+    (output_dir / "metrics.json").write_text(json.dumps(metrics_payload, indent=2), encoding="utf-8")
+
+    model.save(output_dir / "model.keras")
+    _write_yaml(output_dir / "train_config.resolved.yaml", config.model_dump(mode="json"))
+    return model, hist_payload, metrics_payload


### PR DESCRIPTION
### Motivation
- Provide an end-to-end, stage-oriented ML pipeline inside the project to assemble FFT-derived datasets, create reproducible splits, apply train-time preprocessing, build/train Keras models, and evaluate results. 
- Ensure each stage emits resolved configuration artifacts so experiments are reproducible and configs can be inspected (`*.resolved.yaml` / `*.json`).
- Keep runtime dependencies guarded so the package can be imported in environments without heavy ML deps while surfacing clear errors at runtime.

### Description
- Add new package `src/echopress/ml/` exporting stage-level APIs and Pydantic config models: `DatasetBuildConfig`, `SplitConfig`, `PreprocessConfig`, `ModelConfig`, `TrainConfig`, and `EvaluateConfig`.
- Implement `dataset.py` to load FFT artifacts, assemble `X.npy`, `y.npy`, `feature_axis.npy`, `sample_manifest.csv`, and `dataset_summary.json`, and write the resolved config (`dataset_config.resolved.yaml`).
- Implement `splits.py` to produce pressure-stratified, random, and holdout splits, serialize `split.json`, and write the resolved split config.
- Implement `preprocess.py` to fit train-only X/y scaling statistics, provide a transform API, serialize `preprocessing.json`, and write the resolved preprocess config.
- Implement `models.py` with a Keras `fft_mlp` factory driven by `ModelConfig`, and guard model construction with a clear runtime error if TensorFlow is absent.
- Implement `train.py` to run Keras training with `EarlyStopping` and `ReduceLROnPlateau`, write `history.json`, `metrics.json`, and `model.keras`, and emit the resolved train config.
- Implement `evaluate.py` to compute test metrics, write `predictions.csv` and `test_metrics.json`, and generate `prediction_scatter.png` and `residual_hist.png`, plus the resolved evaluate config.

### Testing
- Compiled the new package successfully with `python -m compileall src/echopress/ml`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1478ae05108322ace165144299710e)