### PR TITLE
Add standalone pressure baseline pipeline orchestration

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -1136,6 +1136,20 @@ def eval_pressure_regressor(
     typer.echo(json.dumps({"status": "ok", "model_dir": str(model_dir), "split": split}, indent=2))
 
 
+@app.command("train-pressure-baseline")
+def train_pressure_baseline(
+    fft_dir: Path = typer.Option(..., "--fft-dir", file_okay=False, dir_okay=True),
+    output_dir: Path = typer.Option(..., "--output-dir", file_okay=False, dir_okay=True),
+    config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+) -> None:
+    dataset_dir = output_dir / "pressure_regression_dataset"
+    model_dir = output_dir / "pressure_regressor_tf"
+    build_pressure_dataset(PressureDatasetConfig(fft_dir=fft_dir, output_dir=dataset_dir, config=config))
+    run_train(PressureTrainConfig(dataset_dir=dataset_dir, output_dir=model_dir, config=config))
+    run_evaluate(PressureEvalConfig(dataset_dir=dataset_dir, model_dir=model_dir, split="test"))
+    typer.echo(json.dumps({"status": "ok", "dataset_dir": str(dataset_dir), "model_dir": str(model_dir)}, indent=2))
+
+
 @app.command()
 def viz(ctx: typer.Context, signal: str) -> None:
     """Visualise ``signal`` using matplotlib if available."""

--- a/src/echopress/ml/evaluate.py
+++ b/src/echopress/ml/evaluate.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 import numpy as np, pandas as pd
+from echopress.core.config_io import merge_config, write_resolved_config
 
 @dataclass(frozen=True)
 class PressureEvalConfig:
@@ -15,6 +16,9 @@ def run_evaluate(cfg: PressureEvalConfig):
     import matplotlib.pyplot as plt
     import tensorflow as tf
     ds=Path(cfg.dataset_dir); md=Path(cfg.model_dir); out=md/f"eval_{cfg.split}"; out.mkdir(parents=True, exist_ok=True)
+    default_yml = Path(__file__).resolve().parents[3] / "configs" / "pressure_regression.default.yml"
+    rcfg = merge_config(default_yaml_path=default_yml, cli_values={"dataset_dir": str(ds), "model_dir": str(md), "split": cfg.split})
+    write_resolved_config(rcfg, out / "eval_config.resolved.yml")
     X=np.load(ds/"X.npy"); y=np.load(ds/"y.npy"); split=json.loads((ds/"split.json").read_text())
     idx=np.array(split[cfg.split]); prep=json.loads((md/"preprocessing.json").read_text())
     Xs=(X[idx]-np.array(prep["x_mean"])) / np.array(prep["x_std"])
@@ -25,3 +29,5 @@ def run_evaluate(cfg: PressureEvalConfig):
     (out/"metrics_test.json").write_text(json.dumps({"mae":mae,"rmse":rmse,"r2":r2,"bias":bias,"median_abs_error":med,"max_abs_error":mmax,"n_test":int(len(idx))}, indent=2), encoding="utf-8")
     pd.DataFrame({"y_true":yt,"y_pred":pred,"residual":resid}).to_csv(out/"predictions_test.csv", index=False)
     plt.figure(); plt.scatter(yt,pred,s=10); plt.xlabel("true"); plt.ylabel("pred"); plt.tight_layout(); plt.savefig(out/"prediction_vs_true.png", dpi=170); plt.close()
+    plt.figure(); plt.scatter(yt,resid,s=10); plt.xlabel("pressure_true"); plt.ylabel("residual"); plt.tight_layout(); plt.savefig(out/"residual_vs_pressure.png", dpi=170); plt.close()
+    plt.figure(); plt.hist(resid,bins=30); plt.xlabel("residual"); plt.ylabel("count"); plt.tight_layout(); plt.savefig(out/"residual_hist.png", dpi=170); plt.close()

--- a/src/echopress/ml/splits.py
+++ b/src/echopress/ml/splits.py
@@ -1,19 +1,41 @@
 from __future__ import annotations
 import numpy as np, pandas as pd
 
+def _random_split(indices, train_frac, val_frac, rng):
+    a = np.array(indices, dtype=int)
+    rng.shuffle(a)
+    ntr = int(round(len(a) * train_frac))
+    nv = int(round(len(a) * val_frac))
+    return a[:ntr], a[ntr:ntr+nv], a[ntr+nv:]
+
 def make_pressure_splits(y, manifest, cfg):
-    train_frac = float(cfg.get("train_frac",0.70)); val_frac=float(cfg.get("val_frac",0.15));
-    n = len(y); rng = np.random.default_rng(int(cfg.get("random_seed",42)))
-    idx = np.arange(n)
-    method = cfg.get("method","pressure_stratified")
-    train=[]; val=[]; test=[]
+    train_frac = float(cfg.get("train_frac", 0.70)); val_frac = float(cfg.get("val_frac", 0.15))
+    rng = np.random.default_rng(int(cfg.get("random_seed", 42)))
+    idx = np.arange(len(y), dtype=int)
+    method = cfg.get("method", "pressure_stratified")
+    train, val, test = [], [], []
     if method == "pressure_stratified":
-        q = int(cfg.get("pressure_bins",10))
+        q = int(cfg.get("pressure_bins", 10))
         bins = pd.qcut(pd.Series(y), q=min(q, len(np.unique(y))), duplicates="drop")
         for _, g in pd.Series(idx).groupby(bins):
-            a = g.to_numpy(); rng.shuffle(a); ntr=int(round(len(a)*train_frac)); nv=int(round(len(a)*val_frac))
-            train.extend(a[:ntr]); val.extend(a[ntr:ntr+nv]); test.extend(a[ntr+nv:])
+            tr, va, te = _random_split(g.to_numpy(), train_frac, val_frac, rng)
+            train.extend(tr.tolist()); val.extend(va.tolist()); test.extend(te.tolist())
+    elif method == "by_file_stamp" and "file_stamp" in manifest.columns:
+        groups = manifest.groupby("file_stamp").indices.values()
+        group_ids = np.arange(len(groups))
+        tr_g, va_g, te_g = _random_split(group_ids, train_frac, val_frac, rng)
+        for i in tr_g: train.extend(np.asarray(list(groups[i]), dtype=int).tolist())
+        for i in va_g: val.extend(np.asarray(list(groups[i]), dtype=int).tolist())
+        for i in te_g: test.extend(np.asarray(list(groups[i]), dtype=int).tolist())
+    elif method == "holdout_pressure_range":
+        pmin = cfg.get("holdout_pressure_min"); pmax = cfg.get("holdout_pressure_max")
+        if pmin is None or pmax is None:
+            raise ValueError("holdout_pressure_range requires holdout_pressure_min and holdout_pressure_max")
+        holdout = (y >= float(pmin)) & (y <= float(pmax))
+        test = idx[holdout].tolist()
+        tr, va, _ = _random_split(idx[~holdout], train_frac / max(train_frac + val_frac, 1e-12), 1.0 - (train_frac / max(train_frac + val_frac, 1e-12)), rng)
+        train.extend(tr.tolist()); val.extend(va.tolist())
     else:
-        a = idx.copy(); rng.shuffle(a); ntr=int(round(n*train_frac)); nv=int(round(n*val_frac))
-        train=a[:ntr].tolist(); val=a[ntr:ntr+nv].tolist(); test=a[ntr+nv:].tolist()
-    return {"train": sorted(map(int,train)), "val": sorted(map(int,val)), "test": sorted(map(int,test)), "method": method, "random_seed": int(cfg.get("random_seed",42))}
+        tr, va, te = _random_split(idx, train_frac, val_frac, rng)
+        train, val, test = tr.tolist(), va.tolist(), te.tolist()
+    return {"train": sorted(map(int, train)), "val": sorted(map(int, val)), "test": sorted(map(int, test)), "method": method, "random_seed": int(cfg.get("random_seed", 42))}

--- a/src/echopress/ml/train.py
+++ b/src/echopress/ml/train.py
@@ -32,6 +32,15 @@ def run_train(cfg: PressureTrainConfig):
     h=model.fit(Xtr,ytr,validation_data=(Xva,yva),epochs=int(tcfg.get("epochs",300)),batch_size=int(tcfg.get("batch_size",32)),verbose=int(tcfg.get("verbose",1)),callbacks=cb)
     model.save(out/"model.keras")
     pd.DataFrame(h.history).to_csv(out/"history.csv", index=False)
+    try:
+        import matplotlib.pyplot as plt
+        plt.figure()
+        if "loss" in h.history: plt.plot(h.history["loss"], label="train_loss")
+        if "val_loss" in h.history: plt.plot(h.history["val_loss"], label="val_loss")
+        plt.xlabel("epoch"); plt.ylabel("loss"); plt.legend(); plt.tight_layout()
+        plt.savefig(out / "training_history.png", dpi=170); plt.close()
+    except Exception:
+        pass
     val_pred = model.predict(Xva, verbose=0).reshape(-1) * prep["y_std"] + prep["y_mean"]
     y_true = y[va]
     mae=float(np.mean(np.abs(val_pred-y_true))); rmse=float(np.sqrt(np.mean((val_pred-y_true)**2)))


### PR DESCRIPTION
## Summary
- added optional split methods for pressure regression datasets (`by_file_stamp`, `holdout_pressure_range`) while keeping pressure-stratified default behavior
- extended evaluation outputs to include residual plots and persisted resolved eval config
- added training history plot artifact during model training
- added `train-pressure-baseline` CLI command that orchestrates dataset build → training → test evaluation into separate durable output directories

## Notes
- kept ML pipeline separate from macro/echo/postprocess/FFT stages; commands consume stored outputs and write standalone ML artifacts
- TensorFlow remains optional and loaded only in ML train/eval/model codepaths

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a147aea3ad48322a5df4ac655a21575)