### PR TITLE
Fix per-file FFT feature export for pressure-regression ML pipeline

### DIFF
--- a/src/echopress/core/fft_export.py
+++ b/src/echopress/core/fft_export.py
@@ -33,16 +33,47 @@ def run_fft_postprocessed(cfg: FFTExportConfig) -> dict[str, Any]:
     out_dir.mkdir(parents=True, exist_ok=True)
     write_resolved_config(rcfg, out_dir / "fft-postprocessed_config.resolved.yml")
 
-    in_csv = Path(rcfg["postprocess_dir"]) / "postprocessed_peak_windows.csv"
-    if not in_csv.exists():
-        raise FileNotFoundError("fft-postprocessed requires postprocessed_peak_windows.csv from postprocess-peak-windows")
-    df = pd.read_csv(in_csv)
+    post_dir = Path(rcfg["postprocess_dir"])
+    in_waveforms = post_dir / "secondary_peak_processed_waveforms.npy"
+    in_manifest = post_dir / "secondary_peak_processed_manifest.csv"
+    in_summary = post_dir / "secondary_peak_processed_summary.json"
+    missing = [str(p) for p in [in_waveforms, in_manifest, in_summary] if not p.exists()]
+    if missing:
+        raise FileNotFoundError(
+            "fft-postprocessed requires outputs from postprocess-peak-windows:\n" + "\n".join(missing)
+        )
+
+    waveforms = np.load(in_waveforms)
+    manifest = pd.read_csv(in_manifest)
+    _ = json.loads(in_summary.read_text(encoding="utf-8"))
+
+    if waveforms.ndim != 2:
+        raise ValueError(f"secondary_peak_processed_waveforms.npy must be 2D [n_files, n_samples], got shape={waveforms.shape}")
+    if len(manifest) != int(waveforms.shape[0]):
+        raise ValueError(
+            f"row count mismatch: secondary_peak_processed_manifest.csv has {len(manifest)} rows but waveforms has {waveforms.shape[0]}"
+        )
+
     bins = int(rcfg["fft_bins"])
-    offsets = pd.to_numeric(df.get("first_echo_offset", pd.Series(dtype=float)), errors="coerce").fillna(0).to_numpy(dtype=float)
-    signal = offsets - np.mean(offsets) if offsets.size else np.zeros(1)
-    fft = np.abs(np.fft.rfft(signal, n=bins))
-    np.save(out_dir / "postprocessed_fft.npy", fft.astype(np.float32))
-    pd.DataFrame({"bin": np.arange(len(fft)), "magnitude": fft}).to_csv(out_dir / "postprocessed_fft.csv", index=False)
-    summary = {"n_rows": int(len(df)), "fft_bins": bins, "n_fft_points": int(len(fft))}
-    (out_dir / "fft_postprocessed_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    n_samples = int(waveforms.shape[1])
+    fft_complex = np.fft.rfft(waveforms, n=bins, axis=1)
+    fft_mag = np.abs(fft_complex).astype(np.float32)
+    fft_db = (20.0 * np.log10(np.maximum(fft_mag, 1e-12))).astype(np.float32)
+    row_max = np.max(fft_db, axis=1, keepdims=True)
+    fft_relative_db = (fft_db - row_max).astype(np.float32)
+    fft_cycles_per_window = np.fft.rfftfreq(bins, d=1.0).astype(np.float32) * float(n_samples)
+
+    np.save(out_dir / "fft_mag.npy", fft_mag)
+    np.save(out_dir / "fft_db.npy", fft_db)
+    np.save(out_dir / "fft_relative_db.npy", fft_relative_db)
+    np.save(out_dir / "fft_cycles_per_window.npy", fft_cycles_per_window)
+    manifest.to_csv(out_dir / "fft_manifest.csv", index=False)
+
+    summary = {
+        "n_rows": int(waveforms.shape[0]),
+        "window_samples": n_samples,
+        "fft_bins": bins,
+        "n_fft_points": int(fft_mag.shape[1]),
+    }
+    (out_dir / "fft_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
     return summary

--- a/src/echopress/core/peak_window_postprocess.py
+++ b/src/echopress/core/peak_window_postprocess.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Optional
 
+import numpy as np
 import pandas as pd
 
 from echopress.core.config_io import merge_config, write_resolved_config
@@ -34,12 +35,19 @@ def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, A
 
     echo_path = Path(rcfg["echo_dir"]) / "echo_peak_index.csv"
     windows_path = Path(rcfg["echo_dir"]) / "echo_window_index.csv"
-    if not echo_path.exists() or not windows_path.exists():
-        raise FileNotFoundError("postprocess requires echo_peak_index.csv and echo_window_index.csv from detect-echo-peaks")
+    waveforms_path = Path(rcfg["echo_dir"]) / "echo_window_values.npy"
+    if not echo_path.exists() or not windows_path.exists() or not waveforms_path.exists():
+        raise FileNotFoundError(
+            "postprocess-peak-windows requires echo_peak_index.csv, echo_window_index.csv, and echo_window_values.npy from detect-echo-peaks"
+        )
+
     echo = pd.read_csv(echo_path)
     windows = pd.read_csv(windows_path)
+    waveforms = np.load(waveforms_path)
+
     if rcfg.get("max_echo_peak_order") is not None and "echo_peak_order" in echo.columns:
         echo = echo[echo["echo_peak_order"] <= int(rcfg["max_echo_peak_order"])]
+
     features = (
         echo.groupby(["path", "first_peak_idx"], dropna=False)
         .agg(n_echo_peaks_post=("echo_peak_idx", "count"), first_echo_offset=("echo_peak_offset_from_first_peak", "min"))
@@ -47,7 +55,21 @@ def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, A
     )
     merged = windows.merge(features, how="left", on=["path", "first_peak_idx"])
     merged["n_echo_peaks_post"] = merged["n_echo_peaks_post"].fillna(0).astype(int)
-    merged.to_csv(out_dir / "postprocessed_peak_windows.csv", index=False)
-    summary = {"n_windows": int(len(merged)), "n_echo_peaks": int(len(echo))}
-    (out_dir / "postprocess_peak_windows_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    if waveforms.ndim != 2:
+        raise ValueError(f"echo_window_values.npy must be 2D [n_files, window_samples], got shape={waveforms.shape}")
+    if len(merged) != int(waveforms.shape[0]):
+        raise ValueError(
+            f"row count mismatch: echo_window_index.csv has {len(merged)} rows but echo_window_values.npy has {waveforms.shape[0]} windows"
+        )
+
+    np.save(out_dir / "secondary_peak_processed_waveforms.npy", waveforms.astype(np.float32))
+    merged.to_csv(out_dir / "secondary_peak_processed_manifest.csv", index=False)
+
+    summary = {
+        "n_windows": int(len(merged)),
+        "n_echo_peaks": int(len(echo)),
+        "waveform_length": int(waveforms.shape[1]),
+    }
+    (out_dir / "secondary_peak_processed_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
     return summary

--- a/src/echopress/core/qc_plots.py
+++ b/src/echopress/core/qc_plots.py
@@ -35,7 +35,8 @@ def run_qc_plot(cfg: QCPlotConfig) -> dict[str, object]:
         df = pd.read_csv(cfg.input_dir / "postprocessed_peak_windows.csv")
         ax.hist(pd.to_numeric(df["n_echo_peaks_post"], errors="coerce").dropna(), bins=20)
     else:
-        arr = np.load(cfg.input_dir / "postprocessed_fft.npy")
+        arr = np.load(cfg.input_dir / "fft_relative_db.npy")
+        arr = np.mean(arr, axis=0) if arr.ndim == 2 else arr
         ax.plot(arr)
     ax.set_title(f"{cfg.stage} qc")
     out = cfg.output_dir / f"plot-{cfg.stage}-qc.png"

--- a/src/echopress/ml/dataset.py
+++ b/src/echopress/ml/dataset.py
@@ -42,7 +42,7 @@ def build_pressure_dataset(cfg: PressureDatasetConfig) -> dict[str, Any]:
         keep = np.isfinite(y)
         manifest = manifest.loc[keep].reset_index(drop=True); y = y[keep]
     src = str(rcfg.get("feature_source", "fft_relative_db"))
-    name = {"fft_relative_db":"fft_relative_db.npy","fft-relative-db":"fft_relative_db.npy","fft_db":"fft_db.npy","fft-db":"fft_db.npy","fft_mag":"fft_magnitude.npy","fft-mag":"fft_magnitude.npy"}.get(src, "fft_relative_db.npy")
+    name = {"fft_relative_db":"fft_relative_db.npy","fft-relative-db":"fft_relative_db.npy","fft_db":"fft_db.npy","fft-db":"fft_db.npy","fft_mag":"fft_mag.npy","fft-mag":"fft_mag.npy"}.get(src, "fft_relative_db.npy")
     x_all = np.load(fft_dir / name)
     if len(x_all) != len(pd.read_csv(fft_dir / "fft_manifest.csv")):
         raise ValueError("feature rows do not match fft_manifest.csv")


### PR DESCRIPTION
### Motivation
- The previous FFT exporter produced a single global FFT vector which cannot serve as per-file features required by the pressure-regression ML pipeline.
- The ML dataset code expects one FFT feature row per file (`rows = files`) and specific per-file arrays like `fft_relative_db.npy` and `fft_cycles_per_window.npy`.
- The pipeline must fail early and clearly when the required per-file postprocess artifacts are not present to avoid silent, incorrect ML runs.

### Description
- `postprocess-peak-windows` now requires `echo_window_values.npy` and writes per-file artifacts: `secondary_peak_processed_waveforms.npy`, `secondary_peak_processed_manifest.csv`, and `secondary_peak_processed_summary.json`, with shape/row consistency validation (file: `src/echopress/core/peak_window_postprocess.py`).
- `fft-postprocessed` now reads the per-file waveform matrix and manifest and exports per-file FFT feature matrices and metadata: `fft_mag.npy`, `fft_db.npy`, `fft_relative_db.npy`, `fft_cycles_per_window.npy`, `fft_manifest.csv`, and `fft_summary.json`, and raises clear errors when inputs mismatch (file: `src/echopress/core/fft_export.py`).
- The dataset feature-source mapping was fixed so `fft_mag` resolves to `fft_mag.npy`, and the dataset loader validates that feature rows match `fft_manifest.csv` (file: `src/echopress/ml/dataset.py`).
- QC plotting was updated to load `fft_relative_db.npy` and plot the mean spectrum when the features are 2D, matching the new per-file output format (file: `src/echopress/core/qc_plots.py`).

### Testing
- Compiled the modified modules with `python -m compileall src/echopress/core/peak_window_postprocess.py src/echopress/core/fft_export.py src/echopress/core/qc_plots.py src/echopress/ml/dataset.py` and the compilation completed successfully.
- The new `fft-postprocessed` implementation explicitly raises `FileNotFoundError` or `ValueError` when required per-file artifacts are missing or shapes/row counts mismatch, providing quick automated failure modes for CI/use.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ddda636083229966eafbdcf388ee)