### PR TITLE
Align FFT pipeline docs and tests with ML-ready per-file FFT export

### DIFF
--- a/docs/outputs_reference.md
+++ b/docs/outputs_reference.md
@@ -16,11 +16,15 @@
 
 ## Postprocess stage outputs
 
-- `postprocessed_peak_windows.csv`: merged window-level features.
-- `postprocess_peak_windows_summary.json`: summary counts.
+- `secondary_peak_processed_waveforms.npy`: processed waveform matrix with shape `[n_files, n_samples]`.
+- `secondary_peak_processed_manifest.csv`: per-row metadata aligned to the waveform matrix.
+- `secondary_peak_processed_summary.json`: summary counts.
 
 ## FFT stage outputs
 
-- `postprocessed_fft.npy`: FFT magnitude vector.
-- `postprocessed_fft.csv`: tabular FFT magnitudes per bin.
-- `fft_postprocessed_summary.json`: summary metadata.
+- `fft_cycles_per_window.npy`: frequency axis for FFT bins (cycles per processed window).
+- `fft_mag.npy`: FFT magnitude matrix.
+- `fft_db.npy`: FFT magnitude in dB.
+- `fft_relative_db.npy`: row-normalized dB features for ML.
+- `fft_manifest.csv`: per-row metadata aligned to FFT matrices.
+- `fft_summary.json`: summary metadata.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -34,18 +34,24 @@ Consumes:
 - `echo_window_index.csv`
 
 Produces:
-- `postprocessed_peak_windows.csv`
-- `postprocess_peak_windows_summary.json`
+- `secondary_peak_processed_waveforms.npy`
+- `secondary_peak_processed_manifest.csv`
+- `secondary_peak_processed_summary.json`
 
 ## Stage 4: fft-postprocessed
 
 Consumes:
-- `postprocessed_peak_windows.csv`
+- `secondary_peak_processed_waveforms.npy`
+- `secondary_peak_processed_manifest.csv`
+- `secondary_peak_processed_summary.json`
 
 Produces:
-- `postprocessed_fft.npy`
-- `postprocessed_fft.csv`
-- `fft_postprocessed_summary.json`
+- `fft_cycles_per_window.npy`
+- `fft_mag.npy`
+- `fft_db.npy`
+- `fft_relative_db.npy`
+- `fft_manifest.csv`
+- `fft_summary.json`
 
 ## Typical directory layout
 

--- a/tests/test_fft_export.py
+++ b/tests/test_fft_export.py
@@ -11,19 +11,31 @@ def test_fft_export_writes_numpy_csv_and_summary(tmp_path: Path):
     out_dir = tmp_path / "fft"
     post_dir.mkdir()
 
-    pd.DataFrame(
+    manifest = pd.DataFrame(
         {
             "path": ["a", "b", "c"],
             "first_peak_idx": [1, 2, 3],
             "first_echo_offset": [3.0, 5.0, 9.0],
         }
-    ).to_csv(post_dir / "postprocessed_peak_windows.csv", index=False)
+    )
+    manifest.to_csv(post_dir / "secondary_peak_processed_manifest.csv", index=False)
+    np.save(
+        post_dir / "secondary_peak_processed_waveforms.npy",
+        np.array([[1.0, 2.0, 3.0, 4.0], [2.0, 0.0, 2.0, 0.0], [1.0, 1.0, 1.0, 1.0]], dtype=np.float32),
+    )
+    (post_dir / "secondary_peak_processed_summary.json").write_text("{}", encoding="utf-8")
 
     summary = run_fft_postprocessed(FFTExportConfig(postprocess_dir=post_dir, output_dir=out_dir, fft_bins=16))
     assert summary["fft_bins"] == 16
 
-    arr = np.load(out_dir / "postprocessed_fft.npy")
-    assert arr.ndim == 1
-    assert len(arr) == 9
-    table = pd.read_csv(out_dir / "postprocessed_fft.csv")
-    assert len(table) == len(arr)
+    fft_mag = np.load(out_dir / "fft_mag.npy")
+    fft_db = np.load(out_dir / "fft_db.npy")
+    fft_relative_db = np.load(out_dir / "fft_relative_db.npy")
+    fft_cycles = np.load(out_dir / "fft_cycles_per_window.npy")
+    table = pd.read_csv(out_dir / "fft_manifest.csv")
+
+    assert fft_mag.shape == (3, 9)
+    assert fft_db.shape == fft_mag.shape
+    assert fft_relative_db.shape == fft_mag.shape
+    assert fft_cycles.shape == (9,)
+    assert len(table) == 3


### PR DESCRIPTION
### Motivation
- Ensure the repository documentation and unit tests reflect the ML-ready per-file FFT export format that the ML dataset builder expects (per-file waveform matrix -> per-file FFT matrices) rather than the old global `postprocessed_fft.*` artifacts. 
- Remove the mismatch between the FFT exporter contract and the tests/docs so ML commands like `build-pressure-regression-dataset` can consume the expected artifacts.

### Description
- Updated `tests/test_fft_export.py` to seed `secondary_peak_processed_waveforms.npy`, `secondary_peak_processed_manifest.csv`, and `secondary_peak_processed_summary.json` and to validate outputs `fft_mag.npy`, `fft_db.npy`, `fft_relative_db.npy`, `fft_cycles_per_window.npy`, and `fft_manifest.csv` instead of `postprocessed_fft.*`.
- Updated `docs/pipeline.md` to document that stage 3 produces `secondary_peak_processed_*` artifacts and that stage 4 produces the per-file `fft_*` artifacts and `fft_manifest.csv`.
- Updated `docs/outputs_reference.md` to describe the new postprocess and FFT artifacts used by ML pressure regression.
- No changes were made to the FFT export implementation logic in `src/echopress/core/fft_export.py` in this PR; only tests and docs were aligned to the current exporter behavior.

### Testing
- Running `pytest -q tests/test_fft_export.py` on the original test setup produced a failure due to missing `secondary_peak_processed_*` inputs as expected.  
- After updating the test and docs, `pytest -q tests/test_fft_export.py tests/test_cli_smoke_pipeline.py` completed successfully (both tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e526f8ec8322b749d93db1e86e7d)