### PR TITLE
Replace postprocess-peak-windows with first-peak interval pipeline

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -782,12 +782,27 @@ def clean_align(
 
 @app.command("postprocess-peak-windows")
 def postprocess_peak_windows(
+    macro_dir: Path = typer.Option(..., "--macro-dir", dir_okay=True, file_okay=False, exists=True),
     echo_dir: Path = typer.Option(..., "--echo-dir", dir_okay=True, file_okay=False, exists=True),
     output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False),
     config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
-    max_echo_peak_order: Optional[int] = typer.Option(3, "--max-echo-peak-order"),
+    zero_first_pulse_us: float = typer.Option(2.0, "--zero-first-pulse-us"),
+    peak_neighbor_us: float = typer.Option(0.0, "--peak-neighbor-us"),
+    gain_clip_min: float = typer.Option(0.25, "--gain-clip-min"),
+    gain_clip_max: float = typer.Option(4.0, "--gain-clip-max"),
+    use_last_common_windows: bool = typer.Option(True, "--use-last-common-windows/--use-first-common-windows"),
 ) -> None:
-    summary = run_peak_window_postprocess(PeakWindowPostprocessConfig(echo_dir=echo_dir, output_dir=output_dir, config=config, max_echo_peak_order=max_echo_peak_order))
+    summary = run_peak_window_postprocess(PeakWindowPostprocessConfig(
+        macro_dir=macro_dir,
+        echo_dir=echo_dir,
+        output_dir=output_dir,
+        config=config,
+        zero_first_pulse_us=zero_first_pulse_us,
+        peak_neighbor_us=peak_neighbor_us,
+        gain_clip_min=gain_clip_min,
+        gain_clip_max=gain_clip_max,
+        use_last_common_windows=use_last_common_windows,
+    ))
     typer.echo(json.dumps(summary, indent=2, default=float))
 
 

--- a/src/echopress/core/peak_window_postprocess.py
+++ b/src/echopress/core/peak_window_postprocess.py
@@ -9,22 +9,55 @@ import numpy as np
 import pandas as pd
 
 from echopress.core.config_io import merge_config, write_resolved_config
+from echopress.ingest import load_ostream
 
 
 @dataclass(frozen=True)
 class PeakWindowPostprocessConfig:
+    macro_dir: Path
     echo_dir: Path
     output_dir: Path
     config: Optional[Path] = None
-    max_echo_peak_order: Optional[int] = 3
+    zero_first_pulse_us: float = 2.0
+    peak_neighbor_us: float = 0.0
+    gain_clip_min: float = 0.25
+    gain_clip_max: float = 4.0
+    use_last_common_windows: bool = True
+
+
+DEFAULTS: dict[str, Any] = {
+    "zero_first_pulse_us": 2.0,
+    "peak_neighbor_us": 0.0,
+    "gain_clip_min": 0.25,
+    "gain_clip_max": 4.0,
+    "use_last_common_windows": True,
+}
 
 
 def _resolve_config(cfg: PeakWindowPostprocessConfig) -> dict[str, Any]:
-    default_yml = Path(__file__).resolve().parents[3] / "configs" / "peak_window_postprocess.default.yml"
-    rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=cfg.config, cli_values=asdict(cfg))
+    rcfg = dict(DEFAULTS)
+    if cfg.config is not None:
+        rcfg = merge_config(default_yaml_path=None, user_yaml_path=cfg.config, cli_values=asdict(cfg))
+    else:
+        rcfg.update(asdict(cfg))
+    rcfg["macro_dir"] = str(cfg.macro_dir)
     rcfg["echo_dir"] = str(cfg.echo_dir)
     rcfg["output_dir"] = str(cfg.output_dir)
     return rcfg
+
+
+def _load_channel(path: Path) -> tuple[np.ndarray, float]:
+    o = load_ostream(path, window_mode=False)
+    arr = np.asarray(o.channels)
+    y = arr[:, 0] if arr.ndim == 2 else arr.reshape(-1)
+    ts = np.asarray(getattr(o, "timestamps", []), dtype=float).reshape(-1)
+    fs = 1.0
+    if ts.size > 3:
+        d = np.diff(ts)
+        d = d[np.isfinite(d) & (d > 0)]
+        if d.size:
+            fs = float(1.0 / np.median(d))
+    return y.astype(float), fs
 
 
 def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, Any]:
@@ -33,43 +66,84 @@ def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, A
     out_dir.mkdir(parents=True, exist_ok=True)
     write_resolved_config(rcfg, out_dir / "postprocess-peak-windows_config.resolved.yml")
 
-    echo_path = Path(rcfg["echo_dir"]) / "echo_peak_index.csv"
-    windows_path = Path(rcfg["echo_dir"]) / "echo_window_index.csv"
-    waveforms_path = Path(rcfg["echo_dir"]) / "echo_window_values.npy"
-    if not echo_path.exists() or not windows_path.exists() or not waveforms_path.exists():
-        raise FileNotFoundError(
-            "postprocess-peak-windows requires echo_peak_index.csv, echo_window_index.csv, and echo_window_values.npy from detect-echo-peaks"
-        )
+    first_peak_path = Path(rcfg["macro_dir"]) / "first_peak_index.csv"
+    global_window_path = Path(rcfg["macro_dir"]) / "global_window_size.json"
+    echo_peak_path = Path(rcfg["echo_dir"]) / "echo_peak_index.csv"
+    for p in (first_peak_path, global_window_path, echo_peak_path):
+        if not p.exists():
+            raise FileNotFoundError(f"Missing required input: {p}")
 
-    echo = pd.read_csv(echo_path)
-    windows = pd.read_csv(windows_path)
-    waveforms = np.load(waveforms_path)
+    first_df = pd.read_csv(first_peak_path).dropna(subset=["path", "first_peak_idx"]).copy()
+    first_df["first_peak_idx"] = first_df["first_peak_idx"].astype(int)
+    echo_df = pd.read_csv(echo_peak_path)
 
-    if rcfg.get("max_echo_peak_order") is not None and "echo_peak_order" in echo.columns:
-        echo = echo[echo["echo_peak_order"] <= int(rcfg["max_echo_peak_order"])]
+    with global_window_path.open("r", encoding="utf-8") as f:
+        g = json.load(f)
+    t_global = int(round(float(g.get("T_global_samples", 0))))
 
-    features = (
-        echo.groupby(["path", "first_peak_idx"], dropna=False)
-        .agg(n_echo_peaks_post=("echo_peak_idx", "count"), first_echo_offset=("echo_peak_offset_from_first_peak", "min"))
-        .reset_index()
-    )
-    merged = windows.merge(features, how="left", on=["path", "first_peak_idx"])
-    merged["n_echo_peaks_post"] = merged["n_echo_peaks_post"].fillna(0).astype(int)
+    rows: list[dict[str, Any]] = []
+    segments: list[np.ndarray] = []
+    max_len = 0
+    skipped = 0
+    for path, grp in first_df.groupby("path"):
+        grp = grp.sort_values("first_peak_idx").reset_index(drop=True)
+        if len(grp) < 2:
+            continue
+        if bool(rcfg["use_last_common_windows"]):
+            pairs = list(range(len(grp) - 1))
+        else:
+            pairs = list(range(len(grp) - 1))
+        y, fs = _load_channel(Path(path))
+        z = int(round(float(rcfg["zero_first_pulse_us"]) * 1e-6 * fs))
+        nbh = int(round(float(rcfg["peak_neighbor_us"]) * 1e-6 * fs))
+        for i in pairs:
+            s = int(grp.iloc[i]["first_peak_idx"])
+            e = int(grp.iloc[i + 1]["first_peak_idx"])
+            if e <= s or e > len(y):
+                skipped += 1
+                continue
+            raw = y[s:e].astype(float).copy()
+            proc = raw.copy()
+            if z > 0:
+                proc[: min(z, len(proc))] = 0.0
+            if nbh > 0:
+                rel = None
+                ep = echo_df[(echo_df["path"] == path) & (echo_df["first_peak_idx"] == s)]
+                if len(ep):
+                    rel = int(ep["echo_peak_offset_from_first_peak"].min())
+                if rel is not None:
+                    lo = max(0, rel - nbh)
+                    hi = min(len(proc), rel + nbh + 1)
+                    proc[lo:hi] = 0.0
+            gain = float(np.max(np.abs(raw)) / max(np.max(np.abs(proc)), 1e-12)) if np.max(np.abs(proc)) > 0 else 1.0
+            gain = float(np.clip(gain, float(rcfg["gain_clip_min"]), float(rcfg["gain_clip_max"])))
+            proc = proc * gain
+            segments.append(proc)
+            max_len = max(max_len, len(proc))
+            rows.append({"path": path, "window_index": i, "start_first_peak_idx": s, "end_first_peak_idx": e, "n_samples": len(raw), "gain": gain})
 
-    if waveforms.ndim != 2:
-        raise ValueError(f"echo_window_values.npy must be 2D [n_files, window_samples], got shape={waveforms.shape}")
-    if len(merged) != int(waveforms.shape[0]):
-        raise ValueError(
-            f"row count mismatch: echo_window_index.csv has {len(merged)} rows but echo_window_values.npy has {waveforms.shape[0]} windows"
-        )
+    if not rows:
+        raise RuntimeError("No complete first_peak[j] -> first_peak[j+1] windows available.")
 
-    np.save(out_dir / "secondary_peak_processed_waveforms.npy", waveforms.astype(np.float32))
-    merged.to_csv(out_dir / "secondary_peak_processed_manifest.csv", index=False)
+    raw_aligned = np.zeros((len(rows), max_len), dtype=np.float32)
+    proc_aligned = np.zeros((len(rows), max_len), dtype=np.float32)
+    marker_rows: list[dict[str, Any]] = []
+    gain_rows: list[dict[str, Any]] = []
+    for i, r in enumerate(rows):
+        s = r["n_samples"]
+        raw = _load_channel(Path(r["path"]))[0][r["start_first_peak_idx"]:r["end_first_peak_idx"]]
+        raw_aligned[i, :s] = raw
+        proc_aligned[i, :s] = segments[i]
+        marker_rows.append({"row": i, "start_idx": 0, "end_idx_exclusive": s, "t_global_samples": t_global})
+        gain_rows.append({"row": i, "path": r["path"], "gain": r["gain"]})
 
-    summary = {
-        "n_windows": int(len(merged)),
-        "n_echo_peaks": int(len(echo)),
-        "waveform_length": int(waveforms.shape[1]),
-    }
+    manifest = pd.DataFrame(rows)
+    manifest.to_csv(out_dir / "secondary_peak_processed_manifest.csv", index=False)
+    pd.DataFrame(gain_rows).to_csv(out_dir / "secondary_peak_gain_table.csv", index=False)
+    pd.DataFrame(marker_rows).to_csv(out_dir / "plot_marker_table.csv", index=False)
+    np.save(out_dir / "raw_first_peak_to_first_peak_aligned_waveforms.npy", raw_aligned)
+    np.save(out_dir / "secondary_peak_processed_waveforms.npy", proc_aligned)
+
+    summary = {"n_files": int(manifest["path"].nunique()), "n_windows": int(len(manifest)), "skipped_incomplete": int(skipped)}
     (out_dir / "secondary_peak_processed_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
     return summary

--- a/tests/test_postprocess_peak_windows.py
+++ b/tests/test_postprocess_peak_windows.py
@@ -1,35 +1,92 @@
 from pathlib import Path
 
+import json
+import numpy as np
 import pandas as pd
 
-from echopress.core.peak_window_postprocess import (
-    PeakWindowPostprocessConfig,
-    run_peak_window_postprocess,
-)
+from echopress.core.peak_window_postprocess import PeakWindowPostprocessConfig, run_peak_window_postprocess
 
 
-def test_postprocess_filters_peak_order_and_merges_features(tmp_path: Path):
-    echo_dir = tmp_path / "echo"
-    out_dir = tmp_path / "post"
-    echo_dir.mkdir()
+def _make_npz(path: Path, y: np.ndarray) -> None:
+    ts = np.arange(len(y), dtype=float) * 1e-6
+    np.savez(path, channels=y.reshape(-1, 1), timestamps=ts)
 
-    pd.DataFrame(
-        [
-            {"path": "a.npz", "first_peak_idx": 10, "echo_peak_order": 1, "echo_peak_idx": 14, "echo_peak_offset_from_first_peak": 4},
-            {"path": "a.npz", "first_peak_idx": 10, "echo_peak_order": 3, "echo_peak_idx": 18, "echo_peak_offset_from_first_peak": 8},
-            {"path": "a.npz", "first_peak_idx": 10, "echo_peak_order": 4, "echo_peak_idx": 20, "echo_peak_offset_from_first_peak": 10},
-        ]
-    ).to_csv(echo_dir / "echo_peak_index.csv", index=False)
 
-    pd.DataFrame([{"path": "a.npz", "first_peak_idx": 10, "window_start_idx": 10}]).to_csv(
-        echo_dir / "echo_window_index.csv", index=False
-    )
+def test_peak_to_peak_complete_windows_and_registered_not_used(tmp_path: Path):
+    macro = tmp_path / "macro"
+    echo = tmp_path / "echo"
+    out = tmp_path / "out"
+    macro.mkdir(); echo.mkdir()
+    sig = np.sin(np.linspace(0, 20, 200))
+    p = tmp_path / "a.npz"
+    _make_npz(p, sig)
 
-    summary = run_peak_window_postprocess(
-        PeakWindowPostprocessConfig(echo_dir=echo_dir, output_dir=out_dir, max_echo_peak_order=3)
-    )
-    assert summary["n_windows"] == 1
+    pd.DataFrame([
+        {"path": str(p), "first_peak_idx": x} for x in [10, 30, 60, 100, 150]
+    ]).to_csv(macro / "first_peak_index.csv", index=False)
+    pd.DataFrame([
+        {"path": str(p), "first_peak_idx": x} for x in [30, 100]
+    ]).to_csv(macro / "first_peak_index.registered.csv", index=False)
+    (macro / "global_window_size.json").write_text(json.dumps({"T_global_samples": 40}), encoding="utf-8")
 
-    merged = pd.read_csv(out_dir / "postprocessed_peak_windows.csv")
-    assert merged.loc[0, "n_echo_peaks_post"] == 2
-    assert merged.loc[0, "first_echo_offset"] == 4
+    pd.DataFrame([
+        {"path": str(p), "first_peak_idx": 10, "echo_peak_offset_from_first_peak": 4},
+        {"path": str(p), "first_peak_idx": 30, "echo_peak_offset_from_first_peak": 5},
+    ]).to_csv(echo / "echo_peak_index.csv", index=False)
+
+    summary = run_peak_window_postprocess(PeakWindowPostprocessConfig(macro_dir=macro, echo_dir=echo, output_dir=out))
+    assert summary["n_windows"] == 4
+
+    proc = np.load(out / "secondary_peak_processed_waveforms.npy")
+    raw = np.load(out / "raw_first_peak_to_first_peak_aligned_waveforms.npy")
+    manifest = pd.read_csv(out / "secondary_peak_processed_manifest.csv")
+    assert proc.shape[0] == 4
+    assert raw.shape[0] == 4
+    assert len(manifest) == 4
+
+
+def test_gain_clip_one_is_noop(tmp_path: Path):
+    macro = tmp_path / "macro"
+    echo = tmp_path / "echo"
+    out = tmp_path / "out"
+    macro.mkdir(); echo.mkdir()
+    y = np.linspace(-1.0, 1.0, 80)
+    p = tmp_path / "b.npz"
+    _make_npz(p, y)
+    pd.DataFrame([
+        {"path": str(p), "first_peak_idx": 10},
+        {"path": str(p), "first_peak_idx": 40},
+    ]).to_csv(macro / "first_peak_index.csv", index=False)
+    (macro / "global_window_size.json").write_text(json.dumps({"T_global_samples": 30}), encoding="utf-8")
+    pd.DataFrame([{"path": str(p), "first_peak_idx": 10, "echo_peak_offset_from_first_peak": 2}]).to_csv(echo / "echo_peak_index.csv", index=False)
+
+    run_peak_window_postprocess(PeakWindowPostprocessConfig(macro_dir=macro, echo_dir=echo, output_dir=out, gain_clip_min=1.0, gain_clip_max=1.0, zero_first_pulse_us=0.0, peak_neighbor_us=0.0))
+    proc = np.load(out / "secondary_peak_processed_waveforms.npy")
+    raw = np.load(out / "raw_first_peak_to_first_peak_aligned_waveforms.npy")
+    assert np.allclose(proc, raw)
+
+
+def test_fft_rows_match_processed_rows(tmp_path: Path):
+    macro = tmp_path / "macro"
+    echo = tmp_path / "echo"
+    out = tmp_path / "out"
+    fft_out = tmp_path / "fft"
+    macro.mkdir(); echo.mkdir()
+    p = tmp_path / "c.npz"
+    _make_npz(p, np.random.default_rng(0).normal(size=120))
+    pd.DataFrame([
+        {"path": str(p), "first_peak_idx": 10},
+        {"path": str(p), "first_peak_idx": 50},
+        {"path": str(p), "first_peak_idx": 90},
+    ]).to_csv(macro / "first_peak_index.csv", index=False)
+    (macro / "global_window_size.json").write_text(json.dumps({"T_global_samples": 40}), encoding="utf-8")
+    pd.DataFrame([{"path": str(p), "first_peak_idx": 10, "echo_peak_offset_from_first_peak": 3}]).to_csv(echo / "echo_peak_index.csv", index=False)
+
+    run_peak_window_postprocess(PeakWindowPostprocessConfig(macro_dir=macro, echo_dir=echo, output_dir=out))
+
+    from echopress.core.fft_export import FFTExportConfig, run_fft_postprocessed
+
+    run_fft_postprocessed(FFTExportConfig(postprocess_dir=out, output_dir=fft_out, fft_bins=16))
+    fft = np.load(fft_out / "fft_mag.npy")
+    proc = np.load(out / "secondary_peak_processed_waveforms.npy")
+    assert fft.shape[0] == proc.shape[0]


### PR DESCRIPTION
### Motivation
- Replace the previous postprocess step that simply copied `echo_window_values.npy` with a pipeline that builds complete windows between successive first peaks so downstream FFT/export operates on full first-peak → next-first-peak intervals. 
- Allow more flexible CLI control over zeroing the first pulse, suppressing neighbor samples, and gain clipping when normalizing processed intervals.

### Description
- Replaced implementation of `postprocess-peak-windows` to read `macro_dir/first_peak_index.csv`, `macro_dir/global_window_size.json`, and `echo_dir/echo_peak_index.csv`, and to load raw waveform files referenced by each `path` via `load_ostream` instead of relying on `echo_window_values.npy`.
- New CLI signature exposes `--macro-dir`, `--echo-dir`, `--output-dir`, `--config`, `--zero-first-pulse-us`, `--peak-neighbor-us`, `--gain-clip-min`, `--gain-clip-max`, and the boolean flag pair `--use-last-common-windows / --use-first-common-windows` and passes those into the new config dataclass.
- The processing now constructs all complete `first_peak[j] -> first_peak[j+1]` windows (skipping incomplete intervals), optionally zeros the first `z` samples, optionally mutes a neighborhood around the registered echo peak offset, computes a normalization gain clipped to the configured range, and writes per-window rows and aligned arrays.
- New outputs written to `output_dir` are `secondary_peak_processed_waveforms.npy`, `raw_first_peak_to_first_peak_aligned_waveforms.npy`, `secondary_peak_processed_manifest.csv`, `secondary_peak_gain_table.csv`, `plot_marker_table.csv`, and `secondary_peak_processed_summary.json`.

### Testing
- Added tests exercising: a 5-primary-peak input producing 4 complete windows, ignoring registered peaks for peak-to-peak selection, `gain_clip_min=1` and `gain_clip_max=1` acting as a no-op, and ensuring FFT rows match processed waveform rows.
- Ran `pytest -q tests/test_postprocess_peak_windows.py tests/test_fft_export.py` and the test-suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164600db9c83228aa156f6af77eae7)