### PR TITLE
Add pipeline contract + smoke6 data contract tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pyyaml pandas numpy
+
+      - name: Run contract tests
+        run: pytest -q tests/contracts --maxfail=1
+
+      - name: Upload contract failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-failure-artifacts
+          path: |
+            contracts/pipeline_contract.yaml
+            tests/fixtures/contracts
+
+  data-tests:
+    runs-on: ubuntu-latest
+    needs: contract-tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pyyaml pandas numpy
+
+      - name: Run data tests
+        run: pytest -q tests/data --maxfail=1
+
+      - name: Upload data failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: data-failure-artifacts
+          path: |
+            contracts/pipeline_contract.yaml
+            tests/fixtures/contracts
+            tests/fixtures/datasets/smoke6/expected

--- a/tests/contracts/test_pipeline_contract.py
+++ b/tests/contracts/test_pipeline_contract.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts" / "pipeline_contract.yaml"
+FIXTURES = ROOT / "tests" / "fixtures" / "contracts"
+
+REQUIRED_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "contract_id",
+    "metadata",
+    "dataset",
+    "allowed_stage_ids",
+    "stages",
+}
+
+REQUIRED_STAGE_IDS = {
+    "detect_macro_windows",
+    "detect_echo_peaks",
+    "postprocess_peak_windows",
+    "fft_postprocessed",
+}
+
+
+def _load_yaml(path: Path) -> dict:
+    assert path.exists(), f"Missing fixture file: {path}"
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), f"Expected mapping YAML: {path}"
+    return data
+
+
+def _validate_contract(contract: dict) -> list[str]:
+    errors: list[str] = []
+
+    missing_top = REQUIRED_TOP_LEVEL_KEYS - set(contract.keys())
+    if missing_top:
+        errors.append(f"Missing required top-level keys: {sorted(missing_top)}")
+
+    stage_ids = set(contract.get("allowed_stage_ids", []) or [])
+    missing_stage_defs = REQUIRED_STAGE_IDS - stage_ids
+    if missing_stage_defs:
+        errors.append(f"Missing required stage ids in allowed_stage_ids: {sorted(missing_stage_defs)}")
+
+    stages = contract.get("stages", []) or []
+    stage_defs = {
+        stage.get("stage_id"): stage
+        for stage in stages
+        if isinstance(stage, dict) and stage.get("stage_id")
+    }
+    missing_stage_objects = REQUIRED_STAGE_IDS - set(stage_defs.keys())
+    if missing_stage_objects:
+        errors.append(f"Missing required stage definitions: {sorted(missing_stage_objects)}")
+
+    if any(not isinstance(s, dict) for s in stages):
+        errors.append("Every stage entry must be a mapping")
+
+    for required_stage in REQUIRED_STAGE_IDS:
+        stage = stage_defs.get(required_stage)
+        if not stage:
+            continue
+        outputs = stage.get("required_outputs")
+        if not isinstance(outputs, list) or not outputs:
+            errors.append(
+                f"Stage '{required_stage}' missing critical required_outputs list"
+            )
+
+    return errors
+
+
+def test_pipeline_contract_yaml_has_required_keys_and_stages() -> None:
+    contract = _load_yaml(CONTRACT)
+    errors = _validate_contract(contract)
+    assert not errors, "\n".join(errors)
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "should_pass"),
+    [
+        ("valid_pipeline_contract.yaml", True),
+        ("invalid_missing_required.yaml", False),
+        ("invalid_bad_enum.yaml", False),
+    ],
+)
+def test_contract_fixture_validation(fixture_name: str, should_pass: bool) -> None:
+    fixture_contract = _load_yaml(FIXTURES / fixture_name)
+    errors = _validate_contract(fixture_contract)
+
+    if should_pass:
+        assert not errors, f"Expected fixture {fixture_name} to pass; errors: {errors}"
+    else:
+        assert errors, f"Expected fixture {fixture_name} to fail"

--- a/tests/data/test_artifact_contract_names.py
+++ b/tests/data/test_artifact_contract_names.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts" / "pipeline_contract.yaml"
+
+
+def _load_contract() -> dict:
+    assert CONTRACT.exists(), f"Missing pipeline contract: {CONTRACT}"
+    with CONTRACT.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), "pipeline_contract.yaml must be a mapping"
+    return data
+
+
+def _stage_required_outputs(contract: dict, stage_id: str) -> set[str]:
+    for stage in contract.get("stages", []) or []:
+        if isinstance(stage, dict) and stage.get("stage_id") == stage_id:
+            outputs = stage.get("required_outputs", []) or []
+            return set(outputs)
+    raise AssertionError(f"Missing stage definition: {stage_id}")
+
+
+def test_detect_echo_peaks_requires_echo_window_values() -> None:
+    contract = _load_contract()
+    outputs = _stage_required_outputs(contract, "detect_echo_peaks")
+    assert "echo_window_values.npy" in outputs
+
+
+def test_postprocess_peak_windows_required_outputs() -> None:
+    contract = _load_contract()
+    outputs = _stage_required_outputs(contract, "postprocess_peak_windows")
+    expected = {
+        "secondary_peak_processed_waveforms.npy",
+        "secondary_peak_processed_manifest.csv",
+        "secondary_peak_processed_summary.json",
+        "secondary_peak_gain_table.csv",
+        "plot_marker_table.csv",
+    }
+    missing = expected - outputs
+    assert not missing, f"Missing postprocess outputs: {sorted(missing)}"
+
+
+def test_fft_postprocessed_required_outputs() -> None:
+    contract = _load_contract()
+    outputs = _stage_required_outputs(contract, "fft_postprocessed")
+    expected = {
+        "fft_relative_db.npy",
+        "fft_cycles_per_window.npy",
+        "fft_manifest.csv",
+        "fft_mag.npy",
+        "fft_db.npy",
+        "fft_summary.json",
+    }
+    missing = expected - outputs
+    assert not missing, f"Missing FFT outputs: {sorted(missing)}"

--- a/tests/data/test_smoke6_contract.py
+++ b/tests/data/test_smoke6_contract.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_DIR = ROOT / "tests" / "fixtures" / "datasets" / "smoke6" / "expected"
+
+
+def _load_csv(name: str) -> pd.DataFrame:
+    path = EXPECTED_DIR / name
+    assert path.exists(), f"Missing expected data file: {path}"
+    return pd.read_csv(path)
+
+
+def test_smoke6_primary_and_echo_window_counts() -> None:
+    first_peak_index = _load_csv("first_peak_index.csv")
+
+    assert "file" in first_peak_index.columns
+    peaks_per_file = first_peak_index.groupby("file").size()
+    assert (peaks_per_file == 5).all(), f"Expected 5 primary peaks per file, got {peaks_per_file.to_dict()}"
+
+    peak_to_peak_windows = peaks_per_file - 1
+    assert (peak_to_peak_windows == 4).all(), (
+        "Expected 5 primary peaks to imply 4 complete peak-to-peak windows per file"
+    )
+
+    echo_peak_index = _load_csv("echo_peak_index.csv")
+    echo_window_index = _load_csv("echo_window_index.csv")
+
+    values_path = EXPECTED_DIR / "echo_window_values.npy"
+    assert values_path.exists(), f"Missing expected data file: {values_path}"
+    echo_window_values = np.load(values_path)
+
+    assert echo_window_values.shape[0] == len(echo_window_index)
+    assert len(echo_window_index) == 24
+    assert len(echo_peak_index) == 72


### PR DESCRIPTION
### Motivation
- Introduce automated contract and data-integrity checks for the newly added fixture pack under `contracts/pipeline_contract.yaml` and `tests/fixtures/datasets/smoke6/` to protect pipeline interfaces and downstream consumers. 
- Ensure stage definitions, required outputs, and artifact names are stable and validated by CI. 

### Description
- Added contract validation tests in `tests/contracts/test_pipeline_contract.py` to verify top-level keys, required stage IDs/definitions, non-empty `required_outputs`, and fixture pass/fail behavior for `valid_pipeline_contract.yaml`, `invalid_missing_required.yaml`, and `invalid_bad_enum.yaml`.
- Added smoke6 data integrity checks in `tests/data/test_smoke6_contract.py` that validate `first_peak_index.csv`, `echo_peak_index.csv`, `echo_window_index.csv`, and `echo_window_values.npy` for expected counts (5 primary peaks per file, 4 peak-to-peak windows per file, 24 total windows, and 72 secondary peaks).
- Added artifact-name contract tests in `tests/data/test_artifact_contract_names.py` asserting that `detect_echo_peaks` requires `echo_window_values.npy` and that `postprocess_peak_windows` and `fft_postprocessed` expose the expected required outputs.
- Added a CI workflow at `.github/workflows/ci.yml` that defines `contract-tests` and `data-tests` jobs where `data-tests` depends on `contract-tests`, and configures upload of failure artifacts `contracts/pipeline_contract.yaml`, `tests/fixtures/contracts`, and `tests/fixtures/datasets/smoke6/expected`.

### Testing
- Ran `pytest -q tests/contracts --maxfail=1`, which failed because the workspace is missing `contracts/pipeline_contract.yaml` (test asserts its presence). 
- Ran `pytest -q tests/data --maxfail=1`, which failed for the same missing contract dependency required by artifact-name tests. 
- No CI workflow changes introduce ML training or require TensorFlow in the default CI configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164e6195c8832297e1904c9637d02b)