### PR TITLE
Add tests to validate contract fixture pack zip in-place

### DIFF
--- a/tests/test_contract_fixture_pack.py
+++ b/tests/test_contract_fixture_pack.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import zipfile
+
+
+def test_contract_fixture_pack_exists_and_is_readable_from_zip() -> None:
+    pack = Path(__file__).resolve().parents[1] / "echopress_contract_fixture_pack_v1.zip"
+    assert pack.exists(), "Fixture pack zip must exist at repository root"
+
+    with zipfile.ZipFile(pack) as archive:
+        names = set(archive.namelist())
+
+    required = {
+        "contracts/pipeline_contract.yaml",
+        "tests/fixtures/contracts/valid_pipeline_contract.yaml",
+        "tests/fixtures/contracts/invalid_missing_required.yaml",
+        "tests/fixtures/contracts/invalid_bad_enum.yaml",
+        "tests/fixtures/datasets/smoke6/expected/expected_summary.json",
+    }
+    assert required.issubset(names)
+
+
+def test_contract_fixture_pack_contains_expected_smoke6_raw_frames() -> None:
+    pack = Path(__file__).resolve().parents[1] / "echopress_contract_fixture_pack_v1.zip"
+
+    with zipfile.ZipFile(pack) as archive:
+        raw_frames = [
+            name
+            for name in archive.namelist()
+            if name.startswith("tests/fixtures/datasets/smoke6/raw/") and name.endswith(".npz")
+        ]
+
+    assert len(raw_frames) == 6


### PR DESCRIPTION
### Motivation
- Ensure the repository can validate contract and test fixtures while keeping them packaged in a zip archive rather than committing unzipped binary fixtures.
- Prevent accidental extraction or committing of large binary fixture trees by verifying archive contents in-place.

### Description
- Add `tests/test_contract_fixture_pack.py` containing tests that operate on the zip without extracting it.
- Add a test that asserts the archive `echopress_contract_fixture_pack_v1.zip` exists at the repo root and is readable via `zipfile` and that required contract/fixture paths are present inside the archive.
- Add a test that verifies the `tests/fixtures/datasets/smoke6/raw/` namespace inside the archive contains exactly six `.npz` frames.

### Testing
- Ran `pytest -q tests/test_contract_fixture_pack.py` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16578e777c8322a309205b833ad907)