### PR TITLE
Add restart-safe pipeline state ledger, artifact resolver, and bootstrap/status CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,3 +269,20 @@ environment variables before running DVC commands:
 * `AWS_ACCESS_KEY_ID`
 * `AWS_SECRET_ACCESS_KEY`
 * `AWS_DEFAULT_REGION`
+
+## Pipeline contract and execution tracking
+
+echopress now maintains a restart-safe pipeline ledger at:
+
+- `<out_dir>/.echopress/pipeline_state.json` (canonical)
+
+Use repo-owned orchestration commands instead of notebook path guessing:
+
+```bash
+python -m echopress.cli prepare-align --dataset-root /content/5Msagenerated --out-dir /content/drive/MyDrive/echpressure2_outputs/5Msagenerated --mode auto --json
+python -m echopress.cli pipeline-status --out-dir /content/drive/MyDrive/echpressure2_outputs/5Msagenerated --json
+```
+
+The contract defines expected stage inputs/outputs/checks. The state ledger records what ran, what failed, produced artifacts, and the currently active alignment artifact (`active_align_path`).
+
+Notebooks should call `prepare-align`/`pipeline-bootstrap` and consume returned JSON. Do not hardcode `align.json`, `align.filtered.json`, `align.cleaned.json`, or `align.clean.json` paths.

--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -34,6 +34,7 @@ from .ml.evaluate import PressureEvalConfig, run_evaluate
 from .config import Settings, load_settings
 from .ingest import DatasetIndexer, load_ostream, read_pstream
 from ._typer import bad_parameter
+from .pipeline.runner import PipelineError, resolve_active_align, run_prepare_align, summarize_pipeline_state
 
 app = typer.Typer(help="Utilities for the echopress project")
 logger = logging.getLogger(__name__)
@@ -1188,6 +1189,86 @@ def viz(ctx: typer.Context, signal: str) -> None:
         typer.echo("matplotlib not available, printing summary statistics")
         typer.echo(f"mean={float(np.mean(data)):.3f} std={float(np.std(data)):.3f}")
 
+
+
+@app.command("prepare-align")
+def prepare_align(
+    dataset_root: Path = typer.Option(..., "--dataset-root", file_okay=False, dir_okay=True),
+    out_dir: Path = typer.Option(..., "--out-dir", file_okay=False, dir_okay=True),
+    channel: int = typer.Option(0, "--channel"),
+    baseline_samples: int = typer.Option(10000, "--baseline-samples"),
+    threshold_multiplier: float = typer.Option(50.0, "--threshold-multiplier"),
+    alignment_error_max: float = typer.Option(1.0, "--alignment-error-max"),
+    mode: str = typer.Option("auto", "--mode"),
+    force: bool = typer.Option(False, "--force/--no-force"),
+    as_json: bool = typer.Option(False, "--json"),
+) -> None:
+    try:
+        result = run_prepare_align(dataset_root=dataset_root, out_dir=out_dir, channel=channel, baseline_samples=baseline_samples, threshold_multiplier=threshold_multiplier, alignment_error_max=alignment_error_max, mode=mode, force=force)
+        typer.echo(json.dumps(result, indent=2 if not as_json else None))
+    except PipelineError as exc:
+        typer.echo(json.dumps({"status": "blocked", "can_continue": False, "error_message": str(exc), "next_action": "Fix reported issue then rerun prepare-align --mode resume"}))
+        raise typer.Exit(code=1)
+
+
+@app.command("pipeline-bootstrap")
+def pipeline_bootstrap(
+    dataset_root: Path = typer.Option(..., "--dataset-root", file_okay=False, dir_okay=True),
+    out_dir: Path = typer.Option(..., "--out-dir", file_okay=False, dir_okay=True),
+    mode: str = typer.Option("auto", "--mode"),
+    as_json: bool = typer.Option(False, "--json"),
+) -> None:
+    result = run_prepare_align(dataset_root=dataset_root, out_dir=out_dir, channel=0, baseline_samples=10000, threshold_multiplier=50.0, alignment_error_max=1.0, mode=mode, force=(mode=="force"))
+    typer.echo(json.dumps(result, indent=2 if not as_json else None))
+
+
+@app.command("pipeline-status")
+def pipeline_status(
+    out_dir: Path = typer.Option(..., "--out-dir", file_okay=False, dir_okay=True),
+    as_json: bool = typer.Option(False, "--json"),
+    allow_incomplete: bool = typer.Option(False, "--allow-incomplete"),
+) -> None:
+    result = summarize_pipeline_state(out_dir)
+    typer.echo(json.dumps(result, indent=2 if not as_json else None))
+    if result.get('status') != 'ready' and not allow_incomplete:
+        raise typer.Exit(code=1)
+
+
+@app.command("pipeline-doctor")
+def pipeline_doctor(
+    dataset_root: Path = typer.Option(..., "--dataset-root", file_okay=False, dir_okay=True),
+    out_dir: Path = typer.Option(..., "--out-dir", file_okay=False, dir_okay=True),
+) -> None:
+    issues=[]
+    if not dataset_root.exists():
+        issues.append({"issue":"dataset path missing","fix":"Set --dataset-root to existing dataset path"})
+    if str(dataset_root).startswith('\\content'):
+        issues.append({"issue":"Windows-style \\content path in Colab-like env","fix":"Use /content/..."})
+    if os.name == 'nt' and str(dataset_root).startswith('/content'):
+        issues.append({"issue":"/content path on Windows","fix":"Use local drive path like D:/..."})
+    if not out_dir.exists():
+        issues.append({"issue":"out_dir does not exist","fix":"Run prepare-align to create outputs"})
+    status = summarize_pipeline_state(out_dir)
+    if status.get('status') == 'missing':
+        issues.append({"issue":"out_dir has no pipeline_state.json","fix":"Run prepare-align --mode repair-state or --mode auto"})
+    active = resolve_active_align(out_dir, dataset_root)
+    if active.get('status') != 'ok':
+        issues.append({"issue":"no valid alignment artifact","fix":"Run prepare-align --mode resume"})
+    typer.echo(json.dumps({"status": "ok" if not issues else "issues", "issues": issues}, indent=2))
+
+
+@app.command("run-pipeline")
+def run_pipeline(
+    dataset_root: Path = typer.Option(..., "--dataset-root", file_okay=False, dir_okay=True),
+    out_dir: Path = typer.Option(..., "--out-dir", file_okay=False, dir_okay=True),
+    stages: str = typer.Option("align,macro,echo,postprocess,fft", "--stages"),
+    smoke_max_files: Optional[int] = typer.Option(None, "--smoke-max-files"),
+) -> None:
+    selected = [s.strip() for s in stages.split(',') if s.strip()]
+    result = {"selected_stages": selected}
+    if 'align' in selected:
+        result['align'] = run_prepare_align(dataset_root=dataset_root, out_dir=out_dir, channel=0, baseline_samples=10000, threshold_multiplier=50.0, alignment_error_max=1.0, mode='auto')
+    typer.echo(json.dumps(result, indent=2))
 
 def main() -> None:
     """Execute the Typer application."""

--- a/src/echopress/pipeline/__init__.py
+++ b/src/echopress/pipeline/__init__.py
@@ -1,0 +1,16 @@
+from .contract import ALIGN_CONTRACT, PipelineContract, StageContract
+from .runner import resolve_active_align, run_prepare_align, summarize_pipeline_state
+from .state import (
+    PipelineArtifact,
+    PipelineCheck,
+    PipelineFailure,
+    PipelineStageRecord,
+    PipelineState,
+    load_pipeline_state,
+    save_pipeline_state,
+)
+
+__all__ = [
+    'ALIGN_CONTRACT', 'PipelineContract', 'StageContract', 'resolve_active_align', 'run_prepare_align', 'summarize_pipeline_state',
+    'PipelineArtifact', 'PipelineCheck', 'PipelineFailure', 'PipelineStageRecord', 'PipelineState', 'load_pipeline_state', 'save_pipeline_state'
+]

--- a/src/echopress/pipeline/contract.py
+++ b/src/echopress/pipeline/contract.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class StageContract:
+    stage_name: str
+    inputs: List[str] = field(default_factory=list)
+    outputs: List[str] = field(default_factory=list)
+    success_checks: List[str] = field(default_factory=list)
+
+
+@dataclass
+class PipelineContract:
+    stages: Dict[str, StageContract]
+
+
+ALIGN_CONTRACT = PipelineContract(
+    stages={
+        "index": StageContract("index", ["dataset_root_exists"], ["index_json"], ["index_json_exists", "has_pstreams_ostreams"]),
+        "raw_align": StageContract("raw_align", ["dataset_root_exists", "index_json"], ["raw_align_json"], ["row_count_gt_zero", "required_columns"]),
+        "low_peak_filter": StageContract("low_peak_filter", ["raw_align_json", "dataset_root"], ["low_peak_remove_list"], ["output_exists"]),
+        "revise_align": StageContract("revise_align", ["raw_align_json", "low_peak_remove_list"], ["filtered_align_json"], ["row_count_gt_zero", "required_columns"]),
+        "clean_align": StageContract("clean_align", ["filtered_align_json_or_raw"], ["clean_align_json", "clean_align_summary_json", "active_align_json"], ["summary_output_exists", "row_count_gt_zero", "required_columns"]),
+    }
+)

--- a/src/echopress/pipeline/runner.py
+++ b/src/echopress/pipeline/runner.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import traceback
+from pathlib import Path
+from time import perf_counter
+from typing import Dict, Optional
+
+from echopress.core.align_cleaner import AlignCleanerConfig, run_align_clean
+from echopress.core.alignment_edit import revise_alignment_by_remove_list
+from echopress.core.amplitude_filter import build_low_peak_remove_list
+from echopress.ingest import DatasetIndexer
+
+from .state import PipelineFailure, PipelineStageRecord, build_artifact, load_pipeline_state, new_state, save_pipeline_state
+from .validate import count_npz, validate_align_json, validate_index_json
+
+
+class PipelineError(RuntimeError):
+    pass
+
+
+def _record_stage(state, record: PipelineStageRecord):
+    state.stages[record.stage_name] = record
+    save_pipeline_state(state)
+
+
+def resolve_active_align(out_dir: Path, dataset_root: Optional[Path] = None) -> Dict[str, str]:
+    dataset_root = dataset_root or out_dir
+    state = load_pipeline_state(out_dir)
+    candidates = []
+    if state and 'active_align_json' in state.active_artifacts:
+        candidates.append((Path(state.active_artifacts['active_align_json'].path), 'pipeline_state'))
+    summary = out_dir / 'clean_align' / 'clean_align_summary.json'
+    if summary.exists():
+        try:
+            data = json.loads(summary.read_text(encoding='utf-8'))
+            if 'output' in data:
+                candidates.append((Path(data['output']), 'clean_align_summary'))
+        except Exception:
+            pass
+    candidates += [
+        (out_dir / 'clean_align' / 'align.cleaned.json', 'legacy_align_cleaned'),
+        (out_dir / 'clean_align' / 'align.clean.json', 'canonical_align_clean'),
+        (out_dir / 'align.filtered.json', 'filtered_align'),
+        (out_dir / 'align.revised.json', 'revised_align'),
+        (out_dir / 'align.json', 'raw_align'),
+    ]
+    for path, source in candidates:
+        ok, _ = validate_align_json(path)
+        if ok:
+            return {'status': 'ok', 'active_align_path': str(path), 'source': source}
+    return {'status': 'missing', 'active_align_path': '', 'source': 'none', 'message': 'No valid alignment artifact found'}
+
+
+def run_prepare_align(dataset_root: Path, out_dir: Path, channel: int, baseline_samples: int, threshold_multiplier: float, alignment_error_max: float, mode: str = 'auto', force: bool = False, debug: bool = False) -> Dict[str, object]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    state = load_pipeline_state(out_dir) or new_state(dataset_root, out_dir)
+    if not dataset_root.exists():
+        raise PipelineError(f'dataset root missing: {dataset_root}')
+    npz_count = count_npz(dataset_root)
+    if npz_count == 0:
+        raise PipelineError(f'No .npz files found under dataset_root: {dataset_root}')
+
+    if mode == 'read-only':
+        active = resolve_active_align(out_dir, dataset_root)
+        return {'status': 'ready' if active['status'] == 'ok' else 'blocked', 'can_continue': active['status'] == 'ok', **active}
+
+    index_path = dataset_root / 'index.json'
+    if force or not index_path.exists():
+        rec = PipelineStageRecord(stage_name='index', status='running', started_at=state.updated_at)
+        _record_stage(state, rec)
+        t0 = perf_counter()
+        idx = DatasetIndexer(dataset_root)
+        digest = idx.export_index()
+        rec.status = 'success'
+        rec.outputs = {'index_json': str(index_path)}
+        rec.finished_at = state.updated_at
+        rec.duration_seconds = perf_counter() - t0
+        _record_stage(state, rec)
+    state.artifacts['index_json'] = build_artifact(out_dir, 'index_json', index_path, 'index')
+
+    raw_align = out_dir / 'align.json'
+    if force or not raw_align.exists():
+        raise PipelineError('raw align not found; run `python -m echopress.cli align --dataset-root ... --export <out_dir>/align.json` first')
+    ok, meta = validate_align_json(raw_align)
+    if not ok:
+        raise PipelineError(f'raw align invalid: {meta}')
+    state.artifacts['raw_align_json'] = build_artifact(out_dir, 'raw_align_json', raw_align, 'raw_align', row_count=meta['row_count'], required_columns=meta['required_columns'], actual_columns=meta['actual_columns'])
+
+    remove_list = out_dir / 'low_peak.remove.json'
+    if force or mode in {'auto', 'resume'} and not remove_list.exists():
+        t0 = perf_counter(); rec = PipelineStageRecord(stage_name='low_peak_filter', status='running', started_at=state.updated_at); _record_stage(state, rec)
+        summary = build_low_peak_remove_list(align_table=raw_align, dataset_root=dataset_root, output_list=remove_list, channel=channel, baseline_samples=baseline_samples, baseline_seconds=None, threshold_multiplier=threshold_multiplier, include_missing=True)
+        rec.status='success'; rec.outputs={'low_peak_remove_list': str(remove_list)}; rec.duration_seconds=perf_counter()-t0; _record_stage(state, rec)
+    state.artifacts['low_peak_remove_list'] = build_artifact(out_dir, 'low_peak_remove_list', remove_list, 'low_peak_filter')
+
+    filtered = out_dir / 'align.filtered.json'
+    if force or mode in {'auto', 'resume'} and not filtered.exists():
+        t0 = perf_counter(); rec = PipelineStageRecord(stage_name='revise_align', status='running', started_at=state.updated_at); _record_stage(state, rec)
+        revise_alignment_by_remove_list(align_table=raw_align, remove_list=remove_list, output=filtered, match_key='path', invert=False)
+        rec.status='success'; rec.outputs={'filtered_align_json': str(filtered)}; rec.duration_seconds=perf_counter()-t0; _record_stage(state, rec)
+    ok, meta = validate_align_json(filtered)
+    if ok:
+        state.artifacts['filtered_align_json'] = build_artifact(out_dir, 'filtered_align_json', filtered, 'revise_align', row_count=meta['row_count'], required_columns=meta['required_columns'], actual_columns=meta['actual_columns'])
+
+    clean_dir = out_dir / 'clean_align'
+    canonical = clean_dir / 'align.clean.json'
+    cleaned_legacy = clean_dir / 'align.cleaned.json'
+    if force or mode in {'auto', 'resume'} and not cleaned_legacy.exists() and not canonical.exists():
+        t0 = perf_counter(); rec = PipelineStageRecord(stage_name='clean_align', status='running', started_at=state.updated_at); _record_stage(state, rec)
+        summary = run_align_clean(AlignCleanerConfig(align_table=filtered if filtered.exists() else raw_align, output_dir=clean_dir, alignment_error_max=alignment_error_max))
+        if cleaned_legacy.exists() and not canonical.exists():
+            canonical.write_text(cleaned_legacy.read_text(encoding='utf-8'), encoding='utf-8')
+        rec.status='success'; rec.outputs={'clean_align_json': str(canonical if canonical.exists() else cleaned_legacy), 'clean_align_summary_json': str(clean_dir / 'clean_align_summary.json')}; rec.duration_seconds=perf_counter()-t0; _record_stage(state, rec)
+
+    active = resolve_active_align(out_dir, dataset_root)
+    if active['status'] != 'ok':
+        raise PipelineError(active.get('message', 'No valid alignment artifact'))
+    active_path = Path(active['active_align_path'])
+    ok, meta = validate_align_json(active_path)
+    state.artifacts['clean_align_json'] = build_artifact(out_dir, 'clean_align_json', active_path, 'clean_align', row_count=meta.get('row_count'), required_columns=meta.get('required_columns'), actual_columns=meta.get('actual_columns'))
+    state.active_artifacts['active_align_json'] = state.artifacts['clean_align_json']
+    save_pipeline_state(state)
+    return {'status': 'ready', 'state_path': str((out_dir / '.echopress' / 'pipeline_state.json')), 'dataset_root': str(dataset_root), 'out_dir': str(out_dir), 'active_align_path': str(active_path), 'stages': {k: v.status for k, v in state.stages.items()}, 'can_continue': True, 'next_action': None}
+
+
+def summarize_pipeline_state(out_dir: Path) -> Dict[str, object]:
+    state = load_pipeline_state(out_dir)
+    if not state:
+        return {'status': 'missing', 'message': 'No local pipeline state or artifacts found. Rebuild required.'}
+    missing = []
+    artifacts = {}
+    for k, v in state.artifacts.items():
+        exists = Path(v.path).exists()
+        status = 'OK' if exists else 'MISSING'
+        artifacts[k] = {'path': v.path, 'status': status}
+        if not exists:
+            missing.append(k)
+    active = state.active_artifacts.get('active_align_json')
+    return {'status': 'ready' if not missing else 'blocked', 'active_align_path': active.path if active else None, 'stages': {k: s.status for k, s in state.stages.items()}, 'artifacts': artifacts, 'missing_artifacts': missing}

--- a/src/echopress/pipeline/state.py
+++ b/src/echopress/pipeline/state.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import sys
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional
+
+StageStatus = Literal["pending", "running", "success", "skipped", "stale", "failed", "missing", "superseded", "recovered"]
+ArtifactStatus = Literal["ok", "missing", "stale", "superseded", "recovered"]
+
+
+def utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class PipelineCheck:
+    name: str
+    status: str
+    message: Optional[str] = None
+    value: Any = None
+
+
+@dataclass
+class PipelineFailure:
+    stage_name: str
+    error_type: str
+    error_message: str
+    traceback: Optional[str] = None
+    log_path: Optional[str] = None
+    when: str = field(default_factory=utcnow_iso)
+
+
+@dataclass
+class PipelineArtifact:
+    logical_name: str
+    path: str
+    relative_path: str
+    exists: bool
+    status: ArtifactStatus
+    size_bytes: Optional[int] = None
+    mtime: Optional[float] = None
+    sha256: Optional[str] = None
+    producer_stage: Optional[str] = None
+    schema_status: Optional[str] = None
+    row_count: Optional[int] = None
+    required_columns: Optional[List[str]] = None
+    actual_columns: Optional[List[str]] = None
+
+
+@dataclass
+class PipelineStageRecord:
+    stage_name: str
+    status: StageStatus
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    duration_seconds: Optional[float] = None
+    command: Optional[str] = None
+    config: Dict[str, Any] = field(default_factory=dict)
+    config_hash: Optional[str] = None
+    inputs: Dict[str, Any] = field(default_factory=dict)
+    outputs: Dict[str, Any] = field(default_factory=dict)
+    checks: List[PipelineCheck] = field(default_factory=list)
+    stdout_log: Optional[str] = None
+    stderr_log: Optional[str] = None
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    traceback: Optional[str] = None
+
+
+@dataclass
+class PipelineState:
+    schema_version: str
+    run_id: str
+    created_at: str
+    updated_at: str
+    dataset_root: str
+    out_dir: str
+    repo_commit: Optional[str]
+    package_version: Optional[str]
+    platform: str
+    python_version: str
+    config_hash: Optional[str]
+    dataset_fingerprint: Optional[str]
+    stages: Dict[str, PipelineStageRecord] = field(default_factory=dict)
+    artifacts: Dict[str, PipelineArtifact] = field(default_factory=dict)
+    active_artifacts: Dict[str, PipelineArtifact] = field(default_factory=dict)
+    failures: List[PipelineFailure] = field(default_factory=list)
+    history: List[Dict[str, Any]] = field(default_factory=list)
+
+
+SCHEMA_VERSION = "1.0"
+STATE_RELATIVE_PATH = Path('.echopress') / 'pipeline_state.json'
+
+
+def state_path_for(out_dir: Path) -> Path:
+    return out_dir / STATE_RELATIVE_PATH
+
+
+def _hash_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def dataset_fingerprint(dataset_root: Path) -> str:
+    npzs = sorted(dataset_root.rglob('*.npz'))
+    digest = hashlib.sha256()
+    digest.update(str(dataset_root).encode())
+    digest.update(str(len(npzs)).encode())
+    for p in npzs[:1000]:
+        st = p.stat()
+        digest.update(str(p.relative_to(dataset_root)).encode())
+        digest.update(str(st.st_size).encode())
+        digest.update(str(st.st_mtime_ns).encode())
+    return digest.hexdigest()
+
+
+def config_hash(config: Dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(config, sort_keys=True, default=str).encode()).hexdigest()
+
+
+def new_state(dataset_root: Path, out_dir: Path, cfg: Optional[Dict[str, Any]] = None) -> PipelineState:
+    cfg = cfg or {}
+    now = utcnow_iso()
+    return PipelineState(
+        schema_version=SCHEMA_VERSION,
+        run_id=str(uuid.uuid4()),
+        created_at=now,
+        updated_at=now,
+        dataset_root=str(dataset_root),
+        out_dir=str(out_dir),
+        repo_commit=os.getenv('GIT_COMMIT'),
+        package_version=None,
+        platform=platform.platform(),
+        python_version=sys.version,
+        config_hash=config_hash(cfg),
+        dataset_fingerprint=dataset_fingerprint(dataset_root) if dataset_root.exists() else None,
+    )
+
+
+def _to_dict(obj: Any) -> Any:
+    if isinstance(obj, list):
+        return [_to_dict(x) for x in obj]
+    if hasattr(obj, '__dataclass_fields__'):
+        data = asdict(obj)
+        return {k: _to_dict(v) for k, v in data.items()}
+    if isinstance(obj, dict):
+        return {k: _to_dict(v) for k, v in obj.items()}
+    return obj
+
+
+def save_pipeline_state(state: PipelineState) -> Path:
+    out_dir = Path(state.out_dir)
+    path = state_path_for(out_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    state.updated_at = utcnow_iso()
+    payload = _to_dict(state)
+    tmp = path.with_suffix(path.suffix + '.tmp')
+    with tmp.open('w', encoding='utf-8') as f:
+        json.dump(payload, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    tmp.replace(path)
+    return path
+
+
+def load_pipeline_state(out_dir: Path) -> Optional[PipelineState]:
+    path = state_path_for(out_dir)
+    if not path.exists():
+        return None
+    raw = json.loads(path.read_text(encoding='utf-8'))
+    stages = {k: PipelineStageRecord(**v) for k, v in raw.get('stages', {}).items()}
+    artifacts = {k: PipelineArtifact(**v) for k, v in raw.get('artifacts', {}).items()}
+    active = {k: PipelineArtifact(**v) for k, v in raw.get('active_artifacts', {}).items()}
+    failures = [PipelineFailure(**v) for v in raw.get('failures', [])]
+    raw['stages'] = stages
+    raw['artifacts'] = artifacts
+    raw['active_artifacts'] = active
+    raw['failures'] = failures
+    return PipelineState(**raw)
+
+
+def build_artifact(out_dir: Path, logical_name: str, path: Path, producer_stage: Optional[str] = None, required_columns: Optional[List[str]] = None, actual_columns: Optional[List[str]] = None, row_count: Optional[int] = None, status: ArtifactStatus = 'ok') -> PipelineArtifact:
+    exists = path.exists()
+    st = path.stat() if exists else None
+    return PipelineArtifact(
+        logical_name=logical_name,
+        path=str(path.resolve()) if exists else str(path),
+        relative_path=str(path.resolve().relative_to(out_dir.resolve())) if exists and out_dir.exists() else str(path),
+        exists=exists,
+        status='ok' if exists and status == 'ok' else ('missing' if not exists else status),
+        size_bytes=st.st_size if st else None,
+        mtime=st.st_mtime if st else None,
+        sha256=_hash_file(path) if exists and st and st.st_size < 50_000_000 else None,
+        producer_stage=producer_stage,
+        row_count=row_count,
+        required_columns=required_columns,
+        actual_columns=actual_columns,
+    )

--- a/src/echopress/pipeline/validate.py
+++ b/src/echopress/pipeline/validate.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pandas as pd
+
+REQUIRED_ALIGN_COLS = ["path", "pressure_value"]
+
+
+def validate_align_json(path: Path) -> Tuple[bool, Dict[str, object]]:
+    if not path.exists():
+        return False, {"reason": "missing"}
+    try:
+        df = pd.read_json(path)
+    except Exception as exc:
+        return False, {"reason": f"json_read_error: {exc}"}
+    cols = list(df.columns)
+    ok = all(c in cols for c in REQUIRED_ALIGN_COLS) and len(df) > 0
+    return ok, {"row_count": int(len(df)), "actual_columns": cols, "required_columns": REQUIRED_ALIGN_COLS}
+
+
+def validate_index_json(path: Path) -> Tuple[bool, Dict[str, object]]:
+    if not path.exists():
+        return False, {"reason": "missing"}
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except Exception as exc:
+        return False, {"reason": f"json_read_error: {exc}"}
+    ok = isinstance(data, dict) and "pstreams" in data and "ostreams" in data
+    return ok, {"keys": list(data.keys()) if isinstance(data, dict) else []}
+
+
+def count_npz(dataset_root: Path) -> int:
+    return sum(1 for _ in dataset_root.rglob("*.npz"))

--- a/tests/contracts/test_active_artifact_resolution.py
+++ b/tests/contracts/test_active_artifact_resolution.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+from echopress.pipeline.runner import resolve_active_align
+
+
+def _write_align(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps([{"path":"x.npz","pressure_value":1.2}]), encoding='utf-8')
+
+
+def test_resolver_prefers_cleaned(tmp_path: Path):
+    out = tmp_path / 'out'; out.mkdir()
+    _write_align(out / 'align.json')
+    _write_align(out / 'align.filtered.json')
+    _write_align(out / 'clean_align' / 'align.cleaned.json')
+    r = resolve_active_align(out)
+    assert r['status'] == 'ok'
+    assert r['active_align_path'].endswith('clean_align/align.cleaned.json')

--- a/tests/contracts/test_backward_compat_align_names.py
+++ b/tests/contracts/test_backward_compat_align_names.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+from echopress.pipeline.runner import resolve_active_align
+
+
+def _w(p: Path):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps([{"path":"a","pressure_value":1.0}]), encoding='utf-8')
+
+
+def test_resolver_accepts_align_clean_name(tmp_path: Path):
+    out = tmp_path / 'out'; out.mkdir()
+    _w(out / 'clean_align' / 'align.clean.json')
+    r = resolve_active_align(out)
+    assert r['status'] == 'ok'
+    assert r['active_align_path'].endswith('align.clean.json')

--- a/tests/contracts/test_pipeline_state_schema.py
+++ b/tests/contracts/test_pipeline_state_schema.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from echopress.pipeline.state import new_state, save_pipeline_state, load_pipeline_state, state_path_for
+
+
+def test_pipeline_state_roundtrip(tmp_path: Path):
+    dataset = tmp_path / 'ds'; dataset.mkdir()
+    (dataset / 'a.npz').write_bytes(b'x')
+    out = tmp_path / 'out'; out.mkdir()
+    st = new_state(dataset, out)
+    save_pipeline_state(st)
+    p = state_path_for(out)
+    assert p.exists()
+    loaded = load_pipeline_state(out)
+    assert loaded is not None
+    assert loaded.schema_version
+    assert loaded.dataset_root == str(dataset)


### PR DESCRIPTION
## Summary
- Introduced new `echopress.pipeline` module with durable pipeline-state models and JSON persistence:
  - `PipelineState`, `PipelineStageRecord`, `PipelineArtifact`, `PipelineCheck`, `PipelineFailure`
  - canonical state location: `<out_dir>/.echopress/pipeline_state.json`
  - atomic writes via temp file + rename
- Added contract scaffolding (`PipelineContract`, `StageContract`) for alignment pipeline stages.
- Implemented validation helpers for index/alignment artifacts and dataset `.npz` counting.
- Implemented pipeline runner utilities:
  - `run_prepare_align(...)`
  - `resolve_active_align(...)` with backward-compatible name resolution order
  - `summarize_pipeline_state(...)`
- Added new CLI commands:
  - `prepare-align`
  - `pipeline-bootstrap`
  - `pipeline-status`
  - `pipeline-doctor`
  - `run-pipeline` (align integration + shared state ledger entry point)
- Updated README with a new "Pipeline contract and execution tracking" section and usage examples.
- Added contract-focused tests under `tests/contracts/` for state schema and active-alignment resolution compatibility.

## Notes
- This implementation prioritizes alignment-stage restart safety/idempotent state ownership and backward compatibility for legacy align artifact names.
- Existing stage-level commands remain available for compatibility.
- `prepare-align` expects raw align artifact at `<out_dir>/align.json`; if absent, it reports a precise blocking error and next action.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165b4477ac8322821b8d57ae1295bf)