### PR TITLE
Add CI workflow to run pytest on push and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pytest
+        run: pytest


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml`
- configure GitHub Actions to run on `pull_request` and on pushes to `main`/`master`
- set up Python 3.11, install dependencies from `requirements.txt`, and run `pytest`

## Why
The repository documented CI expectations for running tests, but had no workflow file in `.github/workflows/`. This PR implements that CI pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165c09261883229a7b55fa4b572e10)