### PR TITLE
Fix prepare-align artifact registration when dataset_root differs from out_dir

### DIFF
--- a/src/echopress/pipeline/runner.py
+++ b/src/echopress/pipeline/runner.py
@@ -69,13 +69,19 @@ def run_prepare_align(dataset_root: Path, out_dir: Path, channel: int, baseline_
         active = resolve_active_align(out_dir, dataset_root)
         return {'status': 'ready' if active['status'] == 'ok' else 'blocked', 'can_continue': active['status'] == 'ok', **active}
 
-    index_path = dataset_root / 'index.json'
+    index_path = out_dir / 'index.json'
     if force or not index_path.exists():
         rec = PipelineStageRecord(stage_name='index', status='running', started_at=state.updated_at)
         _record_stage(state, rec)
         t0 = perf_counter()
         idx = DatasetIndexer(dataset_root)
-        digest = idx.export_index()
+        sessions = idx.sessions()
+        index_data = {
+            'pstreams': {sid: [str(p) for p in idx.get_pstreams(sid, fallback=False)] for sid in sessions},
+            'ostreams': {sid: [str(o) for o in idx.get_ostreams(sid, fallback=False)] for sid in sessions},
+        }
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(json.dumps(index_data, indent=2), encoding='utf-8')
         rec.status = 'success'
         rec.outputs = {'index_json': str(index_path)}
         rec.finished_at = state.updated_at

--- a/src/echopress/pipeline/state.py
+++ b/src/echopress/pipeline/state.py
@@ -41,7 +41,7 @@ class PipelineFailure:
 class PipelineArtifact:
     logical_name: str
     path: str
-    relative_path: str
+    relative_path: Optional[str]
     exists: bool
     status: ArtifactStatus
     size_bytes: Optional[int] = None
@@ -195,10 +195,19 @@ def load_pipeline_state(out_dir: Path) -> Optional[PipelineState]:
 def build_artifact(out_dir: Path, logical_name: str, path: Path, producer_stage: Optional[str] = None, required_columns: Optional[List[str]] = None, actual_columns: Optional[List[str]] = None, row_count: Optional[int] = None, status: ArtifactStatus = 'ok') -> PipelineArtifact:
     exists = path.exists()
     st = path.stat() if exists else None
+    resolved_out = out_dir.resolve()
+    resolved_path = path.resolve() if exists else path
+    relative_path: Optional[str]
+    if exists and resolved_path.is_relative_to(resolved_out):
+        relative_path = str(resolved_path.relative_to(resolved_out))
+    elif exists:
+        relative_path = None
+    else:
+        relative_path = str(path)
     return PipelineArtifact(
         logical_name=logical_name,
-        path=str(path.resolve()) if exists else str(path),
-        relative_path=str(path.resolve().relative_to(out_dir.resolve())) if exists and out_dir.exists() else str(path),
+        path=str(resolved_path),
+        relative_path=relative_path,
         exists=exists,
         status='ok' if exists and status == 'ok' else ('missing' if not exists else status),
         size_bytes=st.st_size if st else None,

--- a/tests/contracts/test_prepare_align_artifact_paths.py
+++ b/tests/contracts/test_prepare_align_artifact_paths.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+import json
+
+from echopress.pipeline.runner import run_prepare_align
+from echopress.pipeline.state import build_artifact, load_pipeline_state
+
+
+def test_build_artifact_external_path_does_not_crash(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    external = tmp_path / "dataset" / "index.json"
+    external.parent.mkdir()
+    external.write_text("{}", encoding="utf-8")
+
+    artifact = build_artifact(out_dir, "index_json", external, "index")
+
+    assert artifact.exists is True
+    assert artifact.relative_path is None
+
+
+def test_prepare_align_writes_index_and_state_under_out_dir(tmp_path: Path):
+    dataset_root = tmp_path / "dataset"
+    dataset_root.mkdir()
+    (dataset_root / "sample.npz").write_bytes(b"npz")
+    (dataset_root / "sample.p").write_text("p", encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    valid_align = json.dumps([{"path": "x", "pressure_value": 1.0}])
+    (out_dir / "align.json").write_text(valid_align, encoding="utf-8")
+    (out_dir / "low_peak.remove.json").write_text("[]", encoding="utf-8")
+    (out_dir / "align.filtered.json").write_text(valid_align, encoding="utf-8")
+    clean_dir = out_dir / "clean_align"
+    clean_dir.mkdir()
+    (clean_dir / "align.clean.json").write_text(valid_align, encoding="utf-8")
+
+    result = run_prepare_align(
+        dataset_root=dataset_root,
+        out_dir=out_dir,
+        channel=0,
+        baseline_samples=10,
+        threshold_multiplier=10.0,
+        alignment_error_max=1.0,
+        mode="auto",
+        force=False,
+    )
+
+    assert isinstance(result, dict)
+    assert "status" in result
+    assert (out_dir / ".echopress" / "pipeline_state.json").exists()
+    assert (out_dir / "index.json").exists()
+    assert not (dataset_root / "index.json").exists()
+
+    state = load_pipeline_state(out_dir)
+    assert state is not None
+    idx = state.artifacts["index_json"]
+    assert Path(idx.path) == (out_dir / "index.json").resolve()
+    assert idx.relative_path == "index.json"


### PR DESCRIPTION
### Motivation
- The pipeline crashed when `index.json` lived under `dataset_root` because `build_artifact` assumed artifacts were always under `out_dir` and called `relative_to(out_dir)` unconditionally. 
- Pipeline-generated artifacts must be placed under `out_dir` and the dataset root must be treated as a read-only input to avoid polluting the source dataset.

### Description
- Changed `run_prepare_align` to write the index to `out_dir / 'index.json'` instead of `dataset_root / 'index.json'` and serialize an `index_data` structure into that file. 
- Hardened `build_artifact` to compute `relative_path` only when the resolved artifact path is under `out_dir`, otherwise setting `relative_path` to `None`, and use resolved paths for stored `path`. 
- Updated `PipelineArtifact.relative_path` typing to allow `null` (`Optional[str]`) for external artifacts. 
- Added contract tests (`tests/contracts/test_prepare_align_artifact_paths.py`) to validate external-path robustness and that `prepare-align` writes `index.json` and `pipeline_state.json` under `out_dir` without creating `dataset_root/index.json`.

### Testing
- Ran `pytest -q tests/contracts/test_prepare_align_artifact_paths.py tests/contracts/test_pipeline_state_schema.py` and both tests passed. 
- Verified `pipeline_state.json` is written under `out_dir/.echopress/` and the `index.json` artifact recorded in state points to `out_dir/index.json` with `relative_path == 'index.json'` (as asserted by tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a166620a7888322a6cd730723bb4629)