### PR TITLE
Add backward-compatible migration for pipeline_state.json loading

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -35,6 +35,7 @@ from .config import Settings, load_settings
 from .ingest import DatasetIndexer, load_ostream, read_pstream
 from ._typer import bad_parameter
 from .pipeline.runner import PipelineError, resolve_active_align, run_prepare_align, summarize_pipeline_state, run_prepare_macro, run_prepare_echo, run_prepare_postprocess, run_prepare_fft, run_pipeline_full
+from .pipeline.state import PipelineStateMigrationError
 
 app = typer.Typer(help="Utilities for the echopress project")
 logger = logging.getLogger(__name__)
@@ -1231,6 +1232,10 @@ def prepare_align(
         typer.echo(json.dumps(result, indent=2 if not as_json else None))
     except PipelineError as exc:
         typer.echo(json.dumps({"status": "blocked", "can_continue": False, "error_message": str(exc), "next_action": "Fix reported issue then rerun prepare-align --mode resume"}))
+        raise typer.Exit(code=1)
+    except PipelineStateMigrationError as exc:
+        payload = {"status": "blocked", "can_continue": False, "failed_stage": "load_pipeline_state", "error_message": str(exc), "next_action": "Run pipeline repair-state or move old pipeline_state.json aside"}
+        typer.echo(json.dumps(payload))
         raise typer.Exit(code=1)
 
 

--- a/src/echopress/pipeline/state.py
+++ b/src/echopress/pipeline/state.py
@@ -96,8 +96,12 @@ class PipelineState:
     history: List[Dict[str, Any]] = field(default_factory=list)
 
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"
 STATE_RELATIVE_PATH = Path('.echopress') / 'pipeline_state.json'
+
+
+class PipelineStateMigrationError(RuntimeError):
+    pass
 
 
 def state_path_for(out_dir: Path) -> Path:
@@ -181,16 +185,65 @@ def load_pipeline_state(out_dir: Path) -> Optional[PipelineState]:
     path = state_path_for(out_dir)
     if not path.exists():
         return None
-    raw = json.loads(path.read_text(encoding='utf-8'))
-    stages = {k: PipelineStageRecord(**v) for k, v in raw.get('stages', {}).items()}
-    artifacts = {k: PipelineArtifact(**v) for k, v in raw.get('artifacts', {}).items()}
-    active = {k: PipelineArtifact(**v) for k, v in raw.get('active_artifacts', {}).items()}
-    failures = [PipelineFailure(**v) for v in raw.get('failures', [])]
-    raw['stages'] = stages
-    raw['artifacts'] = artifacts
-    raw['active_artifacts'] = active
-    raw['failures'] = failures
-    return PipelineState(**raw)
+    try:
+        raw = json.loads(path.read_text(encoding='utf-8'))
+        migrated = False
+        resolved_out = out_dir.resolve()
+
+        def _migrate_artifact_dict(v: Dict[str, Any]) -> Dict[str, Any]:
+            nonlocal migrated
+            m = dict(v)
+            p = Path(m.get('path', '')).resolve()
+            in_out_dir = False
+            relative: Optional[Path] = None
+            try:
+                relative = p.relative_to(resolved_out)
+                in_out_dir = True
+            except Exception:
+                in_out_dir = False
+            if 'artifact_scope' not in m:
+                m['artifact_scope'] = 'pipeline' if in_out_dir else 'external'
+                migrated = True
+            rel = m.get('relative_path')
+            rel_valid = isinstance(rel, str) and rel != ''
+            if rel_valid and in_out_dir:
+                try:
+                    (resolved_out / rel).resolve().relative_to(resolved_out)
+                except Exception:
+                    rel_valid = False
+            elif rel_valid and not in_out_dir:
+                rel_valid = False
+            if not rel_valid:
+                m['relative_path'] = str(relative) if in_out_dir and relative is not None else None
+                migrated = True
+            if 'exists' not in m:
+                m['exists'] = p.exists()
+                migrated = True
+            if 'status' not in m:
+                m['status'] = 'ok' if m.get('exists') else 'missing'
+                migrated = True
+            return m
+
+        raw['artifacts'] = {k: _migrate_artifact_dict(v) for k, v in raw.get('artifacts', {}).items()}
+        raw['active_artifacts'] = {k: _migrate_artifact_dict(v) for k, v in raw.get('active_artifacts', {}).items()}
+        if raw.get('schema_version') != SCHEMA_VERSION:
+            raw['schema_version'] = SCHEMA_VERSION
+            migrated = True
+
+        stages = {k: PipelineStageRecord(**v) for k, v in raw.get('stages', {}).items()}
+        artifacts = {k: PipelineArtifact(**v) for k, v in raw.get('artifacts', {}).items()}
+        active = {k: PipelineArtifact(**v) for k, v in raw.get('active_artifacts', {}).items()}
+        failures = [PipelineFailure(**v) for v in raw.get('failures', [])]
+        raw['stages'] = stages
+        raw['artifacts'] = artifacts
+        raw['active_artifacts'] = active
+        raw['failures'] = failures
+        state = PipelineState(**raw)
+        if migrated:
+            save_pipeline_state(state)
+        return state
+    except Exception as exc:
+        raise PipelineStateMigrationError(f'Failed to migrate or load pipeline state at {path}: {exc}') from exc
 
 
 def build_artifact(out_dir: Path, logical_name: str, path: Path, producer_stage: Optional[str] = None, required_columns: Optional[List[str]] = None, actual_columns: Optional[List[str]] = None, row_count: Optional[int] = None, status: ArtifactStatus = 'ok') -> PipelineArtifact:

--- a/tests/contracts/test_pipeline_state_migration.py
+++ b/tests/contracts/test_pipeline_state_migration.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from echopress.cli import app
+from echopress.pipeline.runner import run_prepare_align
+from echopress.pipeline.state import load_pipeline_state, state_path_for
+
+
+def _write_old_state(out_dir: Path, artifact_path: Path, active_path: Path | None = None) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "1.0",
+        "run_id": "old-run",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "dataset_root": str(out_dir),
+        "out_dir": str(out_dir),
+        "repo_commit": None,
+        "package_version": None,
+        "platform": "test",
+        "python_version": "test",
+        "config_hash": None,
+        "dataset_fingerprint": None,
+        "stages": {},
+        "artifacts": {
+            "index_json": {
+                "logical_name": "index_json",
+                "path": str(artifact_path),
+            }
+        },
+        "active_artifacts": {},
+        "failures": [],
+        "history": [],
+    }
+    if active_path is not None:
+        payload["active_artifacts"]["active_align_json"] = {
+            "logical_name": "active_align_json",
+            "path": str(active_path),
+        }
+    state_path_for(out_dir).parent.mkdir(parents=True, exist_ok=True)
+    state_path_for(out_dir).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_old_state_without_artifact_scope_loads(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    inside = out_dir / "index.json"
+    inside.parent.mkdir(parents=True)
+    inside.write_text("{}", encoding="utf-8")
+    _write_old_state(out_dir, inside)
+
+    state = load_pipeline_state(out_dir)
+
+    assert state is not None
+    assert state.artifacts["index_json"].artifact_scope == "pipeline"
+    assert state.artifacts["index_json"].relative_path == "index.json"
+
+
+def test_old_active_artifacts_without_artifact_scope_loads(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    align = out_dir / "clean_align" / "align.clean.json"
+    align.parent.mkdir(parents=True, exist_ok=True)
+    align.write_text(json.dumps([{"path": "x", "pressure_value": 1.0}]), encoding="utf-8")
+    _write_old_state(out_dir, out_dir / "index.json", active_path=align)
+
+    state = load_pipeline_state(out_dir)
+
+    assert state is not None
+    assert state.active_artifacts["active_align_json"].artifact_scope == "pipeline"
+
+
+def test_migrated_artifacts_get_scope_external_and_status(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    external = tmp_path / "dataset" / "index.json"
+    external.parent.mkdir(parents=True)
+    external.write_text("{}", encoding="utf-8")
+    _write_old_state(out_dir, external)
+
+    state = load_pipeline_state(out_dir)
+
+    art = state.artifacts["index_json"]
+    assert art.artifact_scope == "external"
+    assert art.relative_path is None
+    assert art.exists is True
+    assert art.status == "ok"
+
+
+def test_prepare_align_after_restart_with_old_state_returns_ready(tmp_path: Path):
+    dataset_root = tmp_path / "dataset"
+    dataset_root.mkdir()
+    (dataset_root / "sample.npz").write_bytes(b"npz")
+
+    out_dir = tmp_path / "out"
+    valid_align = json.dumps([{"path": "x", "pressure_value": 1.0}])
+    align = out_dir / "clean_align" / "align.clean.json"
+    align.parent.mkdir(parents=True, exist_ok=True)
+    align.write_text(valid_align, encoding="utf-8")
+    _write_old_state(out_dir, out_dir / "index.json", active_path=align)
+
+    result = run_prepare_align(dataset_root, out_dir, 0, 10, 10.0, 1.0, mode="read-only", force=False)
+
+    assert result["can_continue"] is True
+    assert result["active_align_path"] == str(align)
+
+
+def test_prepare_align_json_returns_blocked_on_migration_failure(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    state_path_for(out_dir).parent.mkdir(parents=True, exist_ok=True)
+    state_path_for(out_dir).write_text("{not-json", encoding="utf-8")
+    dataset_root = tmp_path / "dataset"
+    dataset_root.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "prepare-align",
+        "--dataset-root", str(dataset_root),
+        "--out-dir", str(out_dir),
+        "--json",
+    ])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert payload["can_continue"] is False
+    assert payload["failed_stage"] == "load_pipeline_state"
+    assert "next_action" in payload


### PR DESCRIPTION
### Motivation
- Previous `load_pipeline_state()` attempted to instantiate `PipelineArtifact` directly from older `pipeline_state.json` records, which lacked new fields like `artifact_scope`, causing `TypeError` and crashing `prepare-align` after a notebook/kernel restart.
- The goal is to make state loading tolerant of older schema files so existing outputs under `out_dir` remain usable after repo updates without forcing users to manually edit state files.

### Description
- Bump schema identifier to `1.1` and add a migration-aware loader in `src/echopress/pipeline/state.py` that inspects and normalizes artifact dicts before dataclass construction.
- For each artifact record in `artifacts` and `active_artifacts`, infer or backfill missing fields: set `artifact_scope` to `"pipeline"` if the artifact `path` is inside `out_dir` else `"external"`; recompute `relative_path` when the path is inside `out_dir` otherwise set it to `None`; compute `exists` from the filesystem when missing; and set `status` to `"ok"` or `"missing"` when absent.
- Persist any migrated state by re-saving atomically via the existing `save_pipeline_state()` routine after successful load.
- Introduce `PipelineStateMigrationError` and wire `prepare-align` CLI to catch this and emit a blocked JSON payload with `failed_stage="load_pipeline_state"`, `can_continue=false`, `error_message=...`, and `next_action="Run pipeline repair-state or move old pipeline_state.json aside"` instead of tracebacks in `--json` mode.
- Add contract tests `tests/contracts/test_pipeline_state_migration.py` to cover legacy `artifacts` and `active_artifacts` migration, scope/status inference, resume/read-only behavior after restart, and `--json` error payload on migration failure.

### Testing
- Added `tests/contracts/test_pipeline_state_migration.py` and ran `pytest -q tests/contracts/test_pipeline_state_migration.py tests/contracts/test_pipeline_state_schema.py tests/contracts/test_prepare_align_artifact_paths.py`, which completed successfully (all tests passed).
- The new tests exercise legacy-state loading, active artifact handling, resumed `prepare-align` behavior, and CLI JSON error output via `CliRunner` and confirmed the migration and error-handling behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17065ce3c883229dd25fab1c441a1a)