### PR TITLE
Add continuous-train output layout for global periodic postprocess

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -796,6 +796,7 @@ def postprocess_peak_windows(
     use_last_common_windows: bool = typer.Option(True, "--use-last-common-windows/--use-first-common-windows"),
     window_mode: str = typer.Option("peak-to-peak", "--window-mode", help="Windowing mode: peak-to-peak | global-periodic-common"),
     window_anchor: str = typer.Option("first", "--window-anchor", help="Anchor for global-periodic-common: first | last"),
+    window_output_layout: str = typer.Option("period-rows", "--window-output-layout", help="Global periodic output layout: period-rows | continuous-train"),
     use_registered_first_peaks: bool = typer.Option(False, "--use-registered-first-peaks/--no-use-registered-first-peaks"),
     require_registered_first_peaks: bool = typer.Option(False, "--require-registered-first-peaks/--no-require-registered-first-peaks"),
     periodicity_tolerance_frac: float = typer.Option(0.12, "--periodicity-tolerance-frac"),
@@ -807,6 +808,8 @@ def postprocess_peak_windows(
         raise typer.BadParameter("window_mode must be one of: peak-to-peak, global-periodic-common", param_hint="--window-mode")
     if window_anchor not in {"first", "last"}:
         raise typer.BadParameter("window_anchor must be one of: first, last", param_hint="--window-anchor")
+    if window_output_layout not in {"period-rows", "continuous-train"}:
+        raise typer.BadParameter("window_output_layout must be one of: period-rows, continuous-train", param_hint="--window-output-layout")
 
     summary = run_peak_window_postprocess(PeakWindowPostprocessConfig(
         macro_dir=macro_dir,
@@ -821,6 +824,7 @@ def postprocess_peak_windows(
         use_last_common_windows=use_last_common_windows,
         window_mode=window_mode,
         window_anchor=window_anchor,
+        window_output_layout=window_output_layout,
         use_registered_first_peaks=use_registered_first_peaks,
         require_registered_first_peaks=require_registered_first_peaks,
         periodicity_tolerance_frac=periodicity_tolerance_frac,

--- a/src/echopress/core/peak_window_postprocess.py
+++ b/src/echopress/core/peak_window_postprocess.py
@@ -26,6 +26,7 @@ class PeakWindowPostprocessConfig:
     use_last_common_windows: bool = True
     window_mode: str = "peak-to-peak"
     window_anchor: str = "first"
+    window_output_layout: str = "period-rows"
     use_registered_first_peaks: bool = False
     require_registered_first_peaks: bool = False
     periodicity_tolerance_frac: float = 0.12
@@ -43,6 +44,7 @@ DEFAULTS: dict[str, Any] = {
     "use_last_common_windows": True,
     "window_mode": "peak-to-peak",
     "window_anchor": "first",
+    "window_output_layout": "period-rows",
     "use_registered_first_peaks": False,
     "require_registered_first_peaks": False,
     "periodicity_tolerance_frac": 0.12,
@@ -190,35 +192,63 @@ def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, A
     plan_df, plan_summary = build_global_periodic_window_plan(first_df, lengths, window_len, float(rcfg["periodicity_tolerance_frac"]), anchor=str(rcfg["window_anchor"]), max_common_windows=rcfg.get("max_common_windows"))
     plan_df.to_csv(out_dir/"global_periodic_window_plan.csv", index=False)
     summary = dict(plan_summary)
-    summary.update({"use_registered_first_peaks":bool(rcfg["use_registered_first_peaks"]),"used_peak_table":str(used_peak_table),"skipped_incomplete":0,"skipped_bad_periodicity":0,"plan_only":bool(rcfg["plan_only"])})
+    summary.update({"use_registered_first_peaks":bool(rcfg["use_registered_first_peaks"]),"used_peak_table":str(used_peak_table),"skipped_incomplete":0,"skipped_bad_periodicity":0,"plan_only":bool(rcfg["plan_only"]),"window_output_layout":str(rcfg["window_output_layout"])})
     if rcfg["plan_only"]:
         summary["waveform_shape"]=None
         (out_dir/"secondary_peak_processed_summary.json").write_text(json.dumps(summary,indent=2),encoding="utf-8")
         return summary
 
-    raw_aligned=np.zeros((len(plan_df),window_len),dtype=np.float32); proc_aligned=np.zeros((len(plan_df),window_len),dtype=np.float32)
+    layout = str(rcfg["window_output_layout"])
     manifest_rows=[]; gain_rows=[]; marker_rows=[]
-    for i,row in plan_df.iterrows():
-        path=str(row["path"]); y=waveforms[path]; fs=fs_by_path[path]; s=int(row["start_first_peak_idx"]); e=s+window_len; raw=y[s:e]
-        if len(raw)!=window_len: raise RuntimeError(f"Incomplete fixed window for {path}: {s}:{e}")
-        proc=raw.copy(); z=int(round(float(rcfg["zero_first_pulse_us"])*1e-6*fs)); nbh=int(round(float(rcfg["peak_neighbor_us"])*1e-6*fs))
-        proc[:min(z,len(proc))]=0.0
-        if nbh>0:
-            match=echo_df[(echo_df["path"]==path)&(echo_df["first_peak_idx"]==s)]
-            if len(match)==0:
-                same=echo_df[echo_df["path"]==path]
-                if len(same):
-                    d=np.abs(same["first_peak_idx"].astype(int)-s); k=int(d.idxmin())
-                    if int(d.loc[k])<=1: match=same.loc[[k]]
-            if len(match):
-                rel=int(match["echo_peak_offset_from_first_peak"].iloc[0]); lo=max(0,rel-nbh); hi=min(len(proc),rel+nbh+1); proc[lo:hi]=0.0
-        gain=float(np.max(np.abs(raw))/max(np.max(np.abs(proc)),1e-12)) if np.max(np.abs(proc))>0 else 1.0
-        gain=float(np.clip(gain,float(rcfg["gain_clip_min"]),float(rcfg["gain_clip_max"]))); proc*=gain
-        raw_aligned[i,:]=raw; proc_aligned[i,:]=proc
-        gain_rows.append({"row":i,"path":path,"gain":gain}); marker_rows.append({"row":i,"start_idx":0,"end_idx_exclusive":window_len,"t_global_samples":t_global})
-        manifest_rows.append({"path":path,"file":row.get("file",Path(path).name),"pressure_value":row.get("pressure_value",np.nan),"file_index":row.get("file_index",-1),"window_index":i,"selected_window_index":int(row["selected_window_index"]),"start_first_peak_idx":s,"end_idx_exclusive":e,"n_samples":int(row["n_samples"]),"T_global_samples":int(row["T_global_samples"]),"window_mode":"global-periodic-common","window_anchor":rcfg["window_anchor"],"common_window_count":int(row["common_window_count"]),"snap_error_samples":int(row["snap_error_samples"]),"snap_error_frac_of_T":float(row["snap_error_frac_of_T"]),"gain":gain})
-    manifest=pd.DataFrame(manifest_rows)
-    manifest.to_csv(out_dir/"global_periodic_window_manifest.csv",index=False)
+    if layout == "continuous-train":
+        common_window_count = int(plan_df["common_window_count"].iloc[0])
+        train_samples = int(common_window_count * window_len)
+        by_path = plan_df.sort_values(["path", "selected_window_index"]).groupby("path", sort=False)
+        raw_aligned=np.zeros((len(by_path),train_samples),dtype=np.float32); proc_aligned=np.zeros((len(by_path),train_samples),dtype=np.float32)
+        for i, (path, grp) in enumerate(by_path):
+            y=waveforms[str(path)]; fs=fs_by_path[str(path)]; z=int(round(float(rcfg["zero_first_pulse_us"])*1e-6*fs)); nbh=int(round(float(rcfg["peak_neighbor_us"])*1e-6*fs))
+            first_row = grp.iloc[0]
+            train_start = int(first_row["start_first_peak_idx"]); train_end = int(train_start + train_samples)
+            raw = y[train_start:train_end]
+            if len(raw) != train_samples: raise RuntimeError(f"Incomplete continuous train for {path}: {train_start}:{train_end}")
+            proc = raw.copy()
+            for _, prow in grp.iterrows():
+                k = int(prow["selected_window_index"]); period_offset = k * window_len
+                proc[period_offset: min(period_offset + z, len(proc))] = 0.0
+                if nbh > 0:
+                    ps = int(prow["start_first_peak_idx"])
+                    match=echo_df[(echo_df["path"]==path)&(echo_df["first_peak_idx"]==ps)]
+                    if len(match):
+                        rel=int(match["echo_peak_offset_from_first_peak"].iloc[0]); eo = period_offset + rel
+                        lo=max(0,eo-nbh); hi=min(len(proc),eo+nbh+1); proc[lo:hi]=0.0
+            gain=float(np.max(np.abs(raw))/max(np.max(np.abs(proc)),1e-12)) if np.max(np.abs(proc))>0 else 1.0
+            gain=float(np.clip(gain,float(rcfg["gain_clip_min"]),float(rcfg["gain_clip_max"]))); proc*=gain
+            raw_aligned[i,:]=raw; proc_aligned[i,:]=proc
+            gain_rows.append({"row":i,"path":path,"gain":gain}); marker_rows.append({"row":i,"start_idx":0,"end_idx_exclusive":train_samples,"t_global_samples":t_global})
+            manifest_rows.append({"path":path,"file":first_row.get("file",Path(path).name),"pressure_value":first_row.get("pressure_value",np.nan),"file_index":first_row.get("file_index",-1),"window_index":i,"selected_window_index":0,"start_first_peak_idx":train_start,"end_idx_exclusive":train_end,"n_samples":train_samples,"T_global_samples":int(first_row["T_global_samples"]),"window_mode":"global-periodic-common","window_anchor":rcfg["window_anchor"],"window_output_layout":"continuous-train","common_window_count":common_window_count,"gain":gain})
+        manifest=pd.DataFrame(manifest_rows)
+        manifest.to_csv(out_dir/"global_periodic_continuous_train_manifest.csv",index=False)
+        plan_df.to_csv(out_dir/"global_periodic_continuous_train_plan.csv",index=False)
+        np.save(out_dir/"raw_global_periodic_continuous_train_waveforms.npy",raw_aligned)
+        np.save(out_dir/"secondary_peak_global_periodic_continuous_train_processed_waveforms.npy",proc_aligned)
+    else:
+        raw_aligned=np.zeros((len(plan_df),window_len),dtype=np.float32); proc_aligned=np.zeros((len(plan_df),window_len),dtype=np.float32)
+        for i,row in plan_df.iterrows():
+            path=str(row["path"]); y=waveforms[path]; fs=fs_by_path[path]; s=int(row["start_first_peak_idx"]); e=s+window_len; raw=y[s:e]
+            if len(raw)!=window_len: raise RuntimeError(f"Incomplete fixed window for {path}: {s}:{e}")
+            proc=raw.copy(); z=int(round(float(rcfg["zero_first_pulse_us"])*1e-6*fs)); nbh=int(round(float(rcfg["peak_neighbor_us"])*1e-6*fs))
+            proc[:min(z,len(proc))]=0.0
+            if nbh>0:
+                match=echo_df[(echo_df["path"]==path)&(echo_df["first_peak_idx"]==s)]
+                if len(match):
+                    rel=int(match["echo_peak_offset_from_first_peak"].iloc[0]); lo=max(0,rel-nbh); hi=min(len(proc),rel+nbh+1); proc[lo:hi]=0.0
+            gain=float(np.max(np.abs(raw))/max(np.max(np.abs(proc)),1e-12)) if np.max(np.abs(proc))>0 else 1.0
+            gain=float(np.clip(gain,float(rcfg["gain_clip_min"]),float(rcfg["gain_clip_max"]))); proc*=gain
+            raw_aligned[i,:]=raw; proc_aligned[i,:]=proc
+            gain_rows.append({"row":i,"path":path,"gain":gain}); marker_rows.append({"row":i,"start_idx":0,"end_idx_exclusive":window_len,"t_global_samples":t_global})
+            manifest_rows.append({"path":path,"file":row.get("file",Path(path).name),"pressure_value":row.get("pressure_value",np.nan),"file_index":row.get("file_index",-1),"window_index":i,"selected_window_index":int(row["selected_window_index"]),"start_first_peak_idx":s,"end_idx_exclusive":e,"n_samples":int(row["n_samples"]),"T_global_samples":int(row["T_global_samples"]),"window_mode":"global-periodic-common","window_anchor":rcfg["window_anchor"],"window_output_layout":"period-rows","common_window_count":int(row["common_window_count"]),"snap_error_samples":int(row["snap_error_samples"]),"snap_error_frac_of_T":float(row["snap_error_frac_of_T"]),"gain":gain})
+        manifest=pd.DataFrame(manifest_rows)
+        manifest.to_csv(out_dir/"global_periodic_window_manifest.csv",index=False)
     manifest.to_csv(out_dir/"secondary_peak_processed_manifest.csv",index=False)
     pd.DataFrame(gain_rows).to_csv(out_dir/"secondary_peak_gain_table.csv",index=False)
     pd.DataFrame(marker_rows).to_csv(out_dir/"plot_marker_table.csv",index=False)
@@ -226,6 +256,7 @@ def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, A
     np.save(out_dir/"secondary_peak_global_periodic_processed_waveforms.npy",proc_aligned)
     np.save(out_dir/"raw_first_peak_to_first_peak_aligned_waveforms.npy",raw_aligned)
     np.save(out_dir/"secondary_peak_processed_waveforms.npy",proc_aligned)
-    summary.update({"T_global_samples":t_global,"window_samples":window_len,"common_window_count":int(plan_df["common_window_count"].iloc[0]),"n_files":int(manifest["path"].nunique()),"n_windows":int(len(manifest)),"waveform_shape":list(proc_aligned.shape),"method":"global_periodic_common_fixed"})
+    train_samples = int(plan_df["common_window_count"].iloc[0]) * int(window_len)
+    summary.update({"T_global_samples":t_global,"window_samples":window_len,"common_window_count":int(plan_df["common_window_count"].iloc[0]),"n_files":int(manifest["path"].nunique()),"n_windows":int(len(manifest)),"waveform_shape":list(proc_aligned.shape),"period_samples":int(window_len),"train_samples":train_samples,"method":"global_periodic_common_fixed"})
     (out_dir/"secondary_peak_processed_summary.json").write_text(json.dumps(summary,indent=2),encoding="utf-8")
     return summary

--- a/tests/test_postprocess_peak_windows.py
+++ b/tests/test_postprocess_peak_windows.py
@@ -96,6 +96,33 @@ def test_cli_postprocess_global_periodic_common(tmp_path: Path):
     assert summary["waveform_shape"][1] == summary["T_global_samples"]
 
 
+def test_postprocess_global_periodic_continuous_train_shape(tmp_path: Path):
+    macro, echo, out = _prep_fixture(tmp_path)
+    summary = run_peak_window_postprocess(PeakWindowPostprocessConfig(
+        macro_dir=macro, echo_dir=echo, output_dir=out, window_mode="global-periodic-common", window_output_layout="continuous-train"
+    ))
+    arr = np.load(out / "secondary_peak_global_periodic_continuous_train_processed_waveforms.npy")
+    assert arr.shape == (2, 300)
+    assert summary["window_output_layout"] == "continuous-train"
+    assert summary["waveform_shape"] == [2, 300]
+    assert summary["train_samples"] == 300
+    assert (out / "global_periodic_continuous_train_manifest.csv").exists()
+    assert (out / "raw_global_periodic_continuous_train_waveforms.npy").exists()
+
+
+def test_cli_postprocess_global_periodic_continuous_train(tmp_path: Path):
+    macro, echo, out = _prep_fixture(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "postprocess-peak-windows", "--macro-dir", str(macro), "--echo-dir", str(echo), "--output-dir", str(out),
+        "--window-mode", "global-periodic-common", "--window-anchor", "first", "--window-output-layout", "continuous-train"
+    ])
+    assert result.exit_code == 0
+    summary = json.loads((out / "secondary_peak_processed_summary.json").read_text(encoding="utf-8"))
+    assert summary["window_output_layout"] == "continuous-train"
+    assert summary["waveform_shape"] == [2, 300]
+
+
 def test_plan_only(tmp_path: Path):
     macro, echo, out = _prep_fixture(tmp_path)
     summary = run_peak_window_postprocess(PeakWindowPostprocessConfig(macro_dir=macro, echo_dir=echo, output_dir=out, window_mode="global-periodic-common", plan_only=True))


### PR DESCRIPTION
### Motivation
- The existing `global-periodic-common` postprocess emitted one row per period (`[n_files * common_window_count, T_global_samples]`) but the production workflow requires a single continuous multi-period waveform per file instead.
- We need a `continuous-train` layout that slices one contiguous segment starting at the first selected primary peak and spanning `common_window_count * T_global_samples` without splitting or padding.
- The continuous output must still use the global-periodic plan for validation, offsets, and determining `common_window_count` and `T_global_samples` but perform per-period masking and a single gain over the whole train.

### Description
- Added a `window_output_layout` option to `PeakWindowPostprocessConfig` and a CLI flag `--window-output-layout period-rows|continuous-train` with validation in the CLI; default remains `period-rows` for backward compatibility.
- Implemented `continuous-train` handling in `run_peak_window_postprocess` that: uses the existing plan to pick the first anchor peak per file, slices `raw = y[train_start:train_start + common_window_count * window_len]`, validates length, applies per-period zeroing (first pulse and optional echo-neighborhood using `echo_peak_offset_from_first_peak`), computes one `gain` for the whole train, and applies it to the processed waveform.
- Wrote explicit continuous-train artifacts: `raw_global_periodic_continuous_train_waveforms.npy`, `secondary_peak_global_periodic_continuous_train_processed_waveforms.npy`, `global_periodic_continuous_train_manifest.csv`, and `global_periodic_continuous_train_plan.csv`, and preserved backward-compatible aliases (`raw_first_peak_to_first_peak_aligned_waveforms.npy`, `secondary_peak_processed_waveforms.npy`, `secondary_peak_processed_manifest.csv`).
- Summary output now includes `window_output_layout`, `period_samples`, and `train_samples`, and `waveform_shape` reflects the chosen layout (`[n_files, common_window_count * T_global_samples]` for `continuous-train`).

### Testing
- Added unit tests for the new path: `test_postprocess_global_periodic_continuous_train_shape` and a CLI smoke test `test_cli_postprocess_global_periodic_continuous_train` in `tests/test_postprocess_peak_windows.py`.
- Ran `pytest -q tests/test_postprocess_peak_windows.py tests/test_fft_export.py` and the selected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a176d70c3d483229b7efed2e388fef0)