### PR TITLE
Avoid time-domain truncation in fft-postprocessed by default; add --fft-mode/--n-fft/--output-bins

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -841,8 +841,11 @@ def fft_postprocessed(
     output_dir: Path = typer.Option(..., "--output-dir", dir_okay=True, file_okay=False),
     config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
     fft_bins: Optional[int] = typer.Option(256, "--fft-bins"),
+    fft_mode: str = typer.Option("full", "--fft-mode"),
+    n_fft: Optional[int] = typer.Option(None, "--n-fft"),
+    output_bins: Optional[int] = typer.Option(None, "--output-bins"),
 ) -> None:
-    summary = run_fft_postprocessed(FFTExportConfig(postprocess_dir=postprocess_dir, output_dir=output_dir, config=config, fft_bins=fft_bins))
+    summary = run_fft_postprocessed(FFTExportConfig(postprocess_dir=postprocess_dir, output_dir=output_dir, config=config, fft_bins=fft_bins, fft_mode=fft_mode, n_fft=n_fft, output_bins=output_bins))
     typer.echo(json.dumps(summary, indent=2, default=float))
 
 

--- a/src/echopress/core/fft_export.py
+++ b/src/echopress/core/fft_export.py
@@ -17,6 +17,24 @@ class FFTExportConfig:
     output_dir: Path
     config: Optional[Path] = None
     fft_bins: Optional[int] = 256
+    fft_mode: str = "full"
+    n_fft: Optional[int] = None
+    output_bins: Optional[int] = None
+
+
+def _reduce_spectrum_bins(spectrum: np.ndarray, output_bins: int) -> np.ndarray:
+    current_bins = int(spectrum.shape[1])
+    if output_bins >= current_bins:
+        return spectrum
+    edges = np.linspace(0, current_bins, output_bins + 1)
+    reduced = np.empty((spectrum.shape[0], output_bins), dtype=np.float32)
+    for i in range(output_bins):
+        lo = int(np.floor(edges[i]))
+        hi = int(np.floor(edges[i + 1]))
+        if hi <= lo:
+            hi = min(lo + 1, current_bins)
+        reduced[:, i] = np.mean(spectrum[:, lo:hi], axis=1)
+    return reduced
 
 
 def _resolve_config(cfg: FFTExportConfig) -> dict[str, Any]:
@@ -54,14 +72,45 @@ def run_fft_postprocessed(cfg: FFTExportConfig) -> dict[str, Any]:
             f"row count mismatch: secondary_peak_processed_manifest.csv has {len(manifest)} rows but waveforms has {waveforms.shape[0]}"
         )
 
-    bins = int(rcfg["fft_bins"])
     n_samples = int(waveforms.shape[1])
-    fft_complex = np.fft.rfft(waveforms, n=bins, axis=1)
+    fft_mode = str(rcfg.get("fft_mode", "full"))
+    if fft_mode not in {"full", "truncate", "resample-spectrum"}:
+        raise ValueError("fft_mode must be one of: full, truncate, resample-spectrum")
+    n_fft = int(rcfg["n_fft"]) if rcfg.get("n_fft") is not None else n_samples
+    if n_fft <= 0:
+        raise ValueError("n_fft must be positive")
+
+    bins = rcfg.get("output_bins")
+    if bins is None:
+        bins = rcfg.get("fft_bins")
+    output_bins = int(bins) if bins is not None else None
+    if output_bins is not None and output_bins <= 0:
+        raise ValueError("output_bins/fft_bins must be positive")
+
+    cropped_time_domain = False
+    if fft_mode == "truncate":
+        legacy_bins = output_bins if output_bins is not None else int(rcfg.get("fft_bins") or 256)
+        fft_complex = np.fft.rfft(waveforms, n=legacy_bins, axis=1)
+        effective_n_fft = legacy_bins
+        cropped_time_domain = legacy_bins < n_samples
+    else:
+        fft_complex = np.fft.rfft(waveforms, n=n_fft, axis=1)
+        effective_n_fft = n_fft
+
     fft_mag = np.abs(fft_complex).astype(np.float32)
+    if output_bins is not None and output_bins < fft_mag.shape[1]:
+        fft_mag = _reduce_spectrum_bins(fft_mag, output_bins)
     fft_db = (20.0 * np.log10(np.maximum(fft_mag, 1e-12))).astype(np.float32)
     row_max = np.max(fft_db, axis=1, keepdims=True)
     fft_relative_db = (fft_db - row_max).astype(np.float32)
-    fft_cycles_per_window = np.fft.rfftfreq(bins, d=1.0).astype(np.float32) * float(n_samples)
+
+    full_cycles = np.fft.rfftfreq(effective_n_fft, d=1.0).astype(np.float32) * float(n_samples)
+    if output_bins is not None and output_bins < full_cycles.shape[0]:
+        target_x = np.linspace(0.0, 1.0, output_bins, dtype=np.float32)
+        source_x = np.linspace(0.0, 1.0, full_cycles.shape[0], dtype=np.float32)
+        fft_cycles_per_window = np.interp(target_x, source_x, full_cycles).astype(np.float32)
+    else:
+        fft_cycles_per_window = full_cycles
 
     np.save(out_dir / "fft_mag.npy", fft_mag)
     np.save(out_dir / "fft_db.npy", fft_db)
@@ -72,7 +121,12 @@ def run_fft_postprocessed(cfg: FFTExportConfig) -> dict[str, Any]:
     summary = {
         "n_rows": int(waveforms.shape[0]),
         "window_samples": n_samples,
-        "fft_bins": bins,
+        "waveform_samples": n_samples,
+        "fft_bins": output_bins,
+        "output_bins": output_bins,
+        "fft_mode": fft_mode,
+        "n_fft": effective_n_fft,
+        "cropped_time_domain": cropped_time_domain,
         "n_fft_points": int(fft_mag.shape[1]),
     }
     (out_dir / "fft_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")

--- a/src/echopress/pipeline/runner.py
+++ b/src/echopress/pipeline/runner.py
@@ -264,12 +264,12 @@ def run_prepare_postprocess(dataset_root: Path,out_dir: Path,macro_dir: Optional
     save_pipeline_state(state)
     return _stage_result('postprocess',state,{"postprocess_dir":str(post_dir)})
 
-def run_prepare_fft(dataset_root: Path,out_dir: Path,postprocess_dir: Optional[Path]=None,fft_bins:int=1024,mode:str='auto',force:bool=False,**kwargs)->dict[str,object]:
+def run_prepare_fft(dataset_root: Path,out_dir: Path,postprocess_dir: Optional[Path]=None,fft_bins:int=1024,mode:str='auto',force:bool=False,fft_mode:str='full',n_fft:Optional[int]=None,output_bins:Optional[int]=None,**kwargs)->dict[str,object]:
     state=_state_or_new(dataset_root,out_dir)
     if postprocess_dir is None: postprocess_dir=Path(state.active_artifacts['active_postprocess_dir'].path)
     fft_dir=postprocess_dir/'fft_outputs'
     if force or not (fft_dir/'fft_mag.npy').exists():
-        run_fft_postprocessed(FFTExportConfig(postprocess_dir=postprocess_dir,output_dir=fft_dir,fft_bins=fft_bins))
+        run_fft_postprocessed(FFTExportConfig(postprocess_dir=postprocess_dir,output_dir=fft_dir,fft_bins=fft_bins,fft_mode=fft_mode,n_fft=n_fft,output_bins=output_bins))
     state.active_artifacts['active_fft_dir']=build_artifact(out_dir,'active_fft_dir',fft_dir,'fft')
     state.artifacts['fft_mag_npy']=build_artifact(out_dir,'fft_mag_npy',fft_dir/'fft_mag.npy','fft')
     state.stages['fft']=PipelineStageRecord(stage_name='fft',status='success')
@@ -285,6 +285,6 @@ def run_pipeline_full(dataset_root: Path,out_dir: Path,stages: list[str],**kwarg
         elif s=='macro': results[s]=run_prepare_macro(dataset_root,out_dir,run_mode=kwargs.get('run_mode','smoke'),smoke_max_files=kwargs.get('smoke_max_files',5),mode=kwargs.get('mode','auto'),force=kwargs.get('force',False))
         elif s=='echo': results[s]=run_prepare_echo(dataset_root,out_dir,mode=kwargs.get('mode','auto'),force=kwargs.get('force',False))
         elif s=='postprocess': results[s]=run_prepare_postprocess(dataset_root,out_dir,mode=kwargs.get('mode','auto'),force=kwargs.get('force',False))
-        elif s=='fft': results[s]=run_prepare_fft(dataset_root,out_dir,fft_bins=kwargs.get('fft_bins',1024),mode=kwargs.get('mode','auto'),force=kwargs.get('force',False))
+        elif s=='fft': results[s]=run_prepare_fft(dataset_root,out_dir,fft_bins=kwargs.get('fft_bins',1024),mode=kwargs.get('mode','auto'),force=kwargs.get('force',False),fft_mode=kwargs.get('fft_mode','full'),n_fft=kwargs.get('n_fft'),output_bins=kwargs.get('output_bins'))
     st=load_pipeline_state(out_dir)
     return {"status":"ready","can_continue":True,"state_path":str(state_path_for(out_dir)),"selected_stages":selected,"stages":results,"active_artifacts":{k:v.path for k,v in (st.active_artifacts.items() if st else [])}}

--- a/tests/test_fft_export.py
+++ b/tests/test_fft_export.py
@@ -25,8 +25,10 @@ def test_fft_export_writes_numpy_csv_and_summary(tmp_path: Path):
     )
     (post_dir / "secondary_peak_processed_summary.json").write_text("{}", encoding="utf-8")
 
-    summary = run_fft_postprocessed(FFTExportConfig(postprocess_dir=post_dir, output_dir=out_dir, fft_bins=16))
-    assert summary["fft_bins"] == 16
+    summary = run_fft_postprocessed(
+        FFTExportConfig(postprocess_dir=post_dir, output_dir=out_dir, fft_bins=16, output_bins=16, fft_mode="full")
+    )
+    assert summary["output_bins"] == 16
 
     fft_mag = np.load(out_dir / "fft_mag.npy")
     fft_db = np.load(out_dir / "fft_db.npy")
@@ -34,8 +36,46 @@ def test_fft_export_writes_numpy_csv_and_summary(tmp_path: Path):
     fft_cycles = np.load(out_dir / "fft_cycles_per_window.npy")
     table = pd.read_csv(out_dir / "fft_manifest.csv")
 
-    assert fft_mag.shape == (3, 9)
+    assert fft_mag.shape == (3, 3)
     assert fft_db.shape == fft_mag.shape
     assert fft_relative_db.shape == fft_mag.shape
-    assert fft_cycles.shape == (9,)
+    assert fft_cycles.shape == (3,)
     assert len(table) == 3
+
+
+def test_fft_export_full_mode_uses_all_samples_without_time_crop(tmp_path: Path):
+    post_dir = tmp_path / "post"
+    out_dir = tmp_path / "fft"
+    post_dir.mkdir()
+    pd.DataFrame({"path": ["a"], "first_peak_idx": [1], "first_echo_offset": [3.0]}).to_csv(
+        post_dir / "secondary_peak_processed_manifest.csv", index=False
+    )
+    waveform = np.concatenate([np.zeros(1024, dtype=np.float32), np.ones(2048, dtype=np.float32)])
+    np.save(post_dir / "secondary_peak_processed_waveforms.npy", waveform.reshape(1, -1))
+    (post_dir / "secondary_peak_processed_summary.json").write_text("{}", encoding="utf-8")
+
+    summary = run_fft_postprocessed(
+        FFTExportConfig(postprocess_dir=post_dir, output_dir=out_dir, fft_bins=16, output_bins=16, fft_mode="full")
+    )
+    assert summary["waveform_samples"] == 3072
+    assert summary["cropped_time_domain"] is False
+
+    fft_mag = np.load(out_dir / "fft_mag.npy")
+    assert not np.allclose(fft_mag, 0.0)
+
+
+def test_fft_export_truncate_mode_keeps_legacy_behavior(tmp_path: Path):
+    post_dir = tmp_path / "post"
+    out_dir = tmp_path / "fft"
+    post_dir.mkdir()
+    pd.DataFrame({"path": ["a"], "first_peak_idx": [1], "first_echo_offset": [3.0]}).to_csv(
+        post_dir / "secondary_peak_processed_manifest.csv", index=False
+    )
+    waveform = np.concatenate([np.zeros(16, dtype=np.float32), np.ones(32, dtype=np.float32)])
+    np.save(post_dir / "secondary_peak_processed_waveforms.npy", waveform.reshape(1, -1))
+    (post_dir / "secondary_peak_processed_summary.json").write_text("{}", encoding="utf-8")
+
+    summary = run_fft_postprocessed(
+        FFTExportConfig(postprocess_dir=post_dir, output_dir=out_dir, fft_bins=16, fft_mode="truncate")
+    )
+    assert summary["cropped_time_domain"] is True


### PR DESCRIPTION
### Motivation
- Prevent accidental cropping of long continuous-train waveforms when computing FFTs by decoupling transform length from output bin count. 
- Keep legacy behavior available for compatibility while enabling full-waveform analysis by default.

### Description
- Extend `FFTExportConfig` with `fft_mode`, `n_fft`, and `output_bins` and add CLI options `--fft-mode`, `--n-fft`, and `--output-bins` in `fft-postprocessed`.
- Change FFT logic in `run_fft_postprocessed` so `fft_mode="full"` computes `np.fft.rfft(waveforms, n=n_fft, axis=1)` over the full waveform by default and only truncates the time-domain when `fft_mode="truncate"`.
- Add `_reduce_spectrum_bins` to perform post-FFT spectral reduction (bin averaging) so `output_bins` can be smaller than the full spectrum without cropping the waveform in time.
- Compute cycles axis from the actual transform length and interpolate if `output_bins` reduces the spectrum; write enhanced summary JSON with `waveform_samples`, `n_fft`, `output_bins`, `fft_mode`, and `cropped_time_domain`.
- Thread new options through the pipeline runner so pipeline invocations can pass `fft_mode`, `n_fft`, and `output_bins` consistently.

### Testing
- Ran the FFT export unit tests with `pytest -q tests/test_fft_export.py`, which passed.
- Added tests covering full-mode non-cropping (`test_fft_export_full_mode_uses_all_samples_without_time_crop`) and legacy truncate behavior (`test_fft_export_truncate_mode_keeps_legacy_behavior`), and updated the existing export test (`test_fft_export_writes_numpy_csv_and_summary`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1778c59a948322b957b524e0d925ed)