### PR TITLE
Fix continuous-train postprocess fallthrough into legacy alias outputs

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -803,6 +803,8 @@ def postprocess_peak_windows(
     max_common_windows: Optional[int] = typer.Option(None, "--max-common-windows"),
     window_length_samples: Optional[int] = typer.Option(None, "--window-length-samples"),
     plan_only: bool = typer.Option(False, "--plan-only/--write-waveforms"),
+    write_legacy_aliases: bool = typer.Option(False, "--write-legacy-aliases/--no-write-legacy-aliases"),
+    strict_legacy_aliases: bool = typer.Option(False, "--strict-legacy-aliases/--no-strict-legacy-aliases"),
 ) -> None:
     if window_mode not in {"peak-to-peak", "global-periodic-common"}:
         raise typer.BadParameter("window_mode must be one of: peak-to-peak, global-periodic-common", param_hint="--window-mode")
@@ -831,6 +833,8 @@ def postprocess_peak_windows(
         max_common_windows=max_common_windows,
         window_length_samples=window_length_samples,
         plan_only=plan_only,
+        write_legacy_aliases=write_legacy_aliases,
+        strict_legacy_aliases=strict_legacy_aliases,
     ))
     typer.echo(json.dumps(summary, indent=2, default=float))
 

--- a/src/echopress/core/peak_window_postprocess.py
+++ b/src/echopress/core/peak_window_postprocess.py
@@ -58,6 +58,8 @@ class PeakWindowPostprocessConfig:
     max_common_windows: Optional[int] = None
     window_length_samples: Optional[int] = None
     plan_only: bool = False
+    write_legacy_aliases: bool = False
+    strict_legacy_aliases: bool = False
 
 
 DEFAULTS: dict[str, Any] = {
@@ -76,6 +78,8 @@ DEFAULTS: dict[str, Any] = {
     "max_common_windows": None,
     "window_length_samples": None,
     "plan_only": False,
+    "write_legacy_aliases": False,
+    "strict_legacy_aliases": False,
 }
 
 
@@ -226,6 +230,8 @@ def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, A
         return summary
 
     layout = str(rcfg["window_output_layout"])
+    write_legacy_aliases = bool(rcfg.get("write_legacy_aliases", False))
+    strict_legacy_aliases = bool(rcfg.get("strict_legacy_aliases", False))
     manifest_rows=[]; gain_rows=[]; marker_rows=[]
     if layout == "continuous-train":
         common_window_count = int(plan_df["common_window_count"].iloc[0])
@@ -258,6 +264,42 @@ def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, A
         plan_df.to_csv(out_dir/"global_periodic_continuous_train_plan.csv",index=False)
         np.save(out_dir/"raw_global_periodic_continuous_train_waveforms.npy",raw_aligned)
         np.save(out_dir/"secondary_peak_global_periodic_continuous_train_processed_waveforms.npy",proc_aligned)
+        pd.DataFrame(gain_rows).to_csv(out_dir/"secondary_peak_gain_table.csv",index=False)
+        pd.DataFrame(marker_rows).to_csv(out_dir/"plot_marker_table.csv",index=False)
+        train_samples = int(plan_df["common_window_count"].iloc[0]) * int(window_len)
+        summary.update({
+            "window_mode": "global-periodic-common",
+            "window_output_layout": "continuous-train",
+            "T_global_samples": t_global,
+            "period_samples": int(window_len),
+            "window_samples": int(window_len),
+            "common_window_count": int(plan_df["common_window_count"].iloc[0]),
+            "train_samples": train_samples,
+            "n_files": int(manifest["path"].nunique()),
+            "n_rows": int(manifest["path"].nunique()),
+            "n_periods_total": int(len(plan_df)),
+            "n_windows": int(len(plan_df)),
+            "waveform_shape": list(proc_aligned.shape),
+            "source_layout": "continuous-train",
+            "method": "global_periodic_common_continuous_train",
+            "gain_clip_min": float(rcfg["gain_clip_min"]),
+            "gain_clip_max": float(rcfg["gain_clip_max"]),
+            "peak_neighbor_us": float(rcfg["peak_neighbor_us"]),
+            "zero_first_pulse_us": float(rcfg["zero_first_pulse_us"]),
+            "used_peak_table": str(used_peak_table),
+            "plan_only": False,
+        })
+        (out_dir/"secondary_peak_processed_summary.json").write_text(json.dumps(summary,indent=2),encoding="utf-8")
+        _write_waveform_products_registry(out_dir, summary)
+        if write_legacy_aliases:
+            try:
+                manifest.to_csv(out_dir/"secondary_peak_processed_manifest.csv",index=False)
+                np.save(out_dir/"raw_first_peak_to_first_peak_aligned_waveforms.npy",raw_aligned)
+                np.save(out_dir/"secondary_peak_processed_waveforms.npy",proc_aligned)
+            except Exception:
+                if strict_legacy_aliases:
+                    raise
+        return summary
     else:
         raw_aligned=np.zeros((len(plan_df),window_len),dtype=np.float32); proc_aligned=np.zeros((len(plan_df),window_len),dtype=np.float32)
         for i,row in plan_df.iterrows():
@@ -276,15 +318,20 @@ def run_peak_window_postprocess(cfg: PeakWindowPostprocessConfig) -> dict[str, A
             manifest_rows.append({"path":path,"file":row.get("file",Path(path).name),"pressure_value":row.get("pressure_value",np.nan),"file_index":row.get("file_index",-1),"window_index":i,"selected_window_index":int(row["selected_window_index"]),"start_first_peak_idx":s,"end_idx_exclusive":e,"n_samples":int(row["n_samples"]),"T_global_samples":int(row["T_global_samples"]),"window_mode":"global-periodic-common","window_anchor":rcfg["window_anchor"],"window_output_layout":"period-rows","common_window_count":int(row["common_window_count"]),"snap_error_samples":int(row["snap_error_samples"]),"snap_error_frac_of_T":float(row["snap_error_frac_of_T"]),"gain":gain})
         manifest=pd.DataFrame(manifest_rows)
         manifest.to_csv(out_dir/"global_periodic_window_manifest.csv",index=False)
-    manifest.to_csv(out_dir/"secondary_peak_processed_manifest.csv",index=False)
     pd.DataFrame(gain_rows).to_csv(out_dir/"secondary_peak_gain_table.csv",index=False)
     pd.DataFrame(marker_rows).to_csv(out_dir/"plot_marker_table.csv",index=False)
     np.save(out_dir/"raw_global_periodic_aligned_waveforms.npy",raw_aligned)
     np.save(out_dir/"secondary_peak_global_periodic_processed_waveforms.npy",proc_aligned)
-    np.save(out_dir/"raw_first_peak_to_first_peak_aligned_waveforms.npy",raw_aligned)
-    np.save(out_dir/"secondary_peak_processed_waveforms.npy",proc_aligned)
     train_samples = int(plan_df["common_window_count"].iloc[0]) * int(window_len)
-    summary.update({"T_global_samples":t_global,"window_samples":window_len,"common_window_count":int(plan_df["common_window_count"].iloc[0]),"n_files":int(manifest["path"].nunique()),"n_windows":int(len(manifest)),"waveform_shape":list(proc_aligned.shape),"period_samples":int(window_len),"train_samples":train_samples,"method":"global_periodic_common_fixed"})
+    summary.update({"T_global_samples":t_global,"window_samples":window_len,"common_window_count":int(plan_df["common_window_count"].iloc[0]),"n_files":int(manifest["path"].nunique()),"n_rows":int(len(manifest)),"n_windows":int(len(manifest)),"waveform_shape":list(proc_aligned.shape),"period_samples":int(window_len),"train_samples":train_samples,"n_periods_total":int(len(manifest)),"method":"global_periodic_common_fixed"})
     (out_dir/"secondary_peak_processed_summary.json").write_text(json.dumps(summary,indent=2),encoding="utf-8")
     _write_waveform_products_registry(out_dir, summary)
+    if write_legacy_aliases:
+        try:
+            manifest.to_csv(out_dir/"secondary_peak_processed_manifest.csv",index=False)
+            np.save(out_dir/"raw_first_peak_to_first_peak_aligned_waveforms.npy",raw_aligned)
+            np.save(out_dir/"secondary_peak_processed_waveforms.npy",proc_aligned)
+        except Exception:
+            if strict_legacy_aliases:
+                raise
     return summary

--- a/tests/test_postprocess_peak_windows.py
+++ b/tests/test_postprocess_peak_windows.py
@@ -11,6 +11,8 @@ from echopress.core.peak_window_postprocess import (
     build_global_periodic_window_plan,
     run_peak_window_postprocess,
 )
+from echopress.core.waveform_products import resolve_waveform_product
+from echopress.core.fft_export import FFTExportConfig, run_fft_postprocessed
 
 
 def _make_npz(path: Path, y: np.ndarray) -> None:
@@ -108,6 +110,11 @@ def test_postprocess_global_periodic_continuous_train_shape(tmp_path: Path):
     assert summary["train_samples"] == 300
     assert (out / "global_periodic_continuous_train_manifest.csv").exists()
     assert (out / "raw_global_periodic_continuous_train_waveforms.npy").exists()
+    assert summary["n_rows"] == 2
+    assert summary["n_periods_total"] == 6
+    assert summary["method"] == "global_periodic_common_continuous_train"
+    assert not (out / "raw_first_peak_to_first_peak_aligned_waveforms.npy").exists()
+    assert not (out / "secondary_peak_processed_waveforms.npy").exists()
 
 
 def test_cli_postprocess_global_periodic_continuous_train(tmp_path: Path):
@@ -143,3 +150,29 @@ def test_postprocess_writes_waveform_products_continuous_train(tmp_path: Path):
     assert "raw_continuous_train" in products
     summary = json.loads((out / "secondary_peak_processed_summary.json").read_text(encoding="utf-8"))
     assert products["processed_continuous_train"]["shape"] == summary["waveform_shape"]
+
+
+def test_waveform_products_resolves_processed_continuous_train(tmp_path: Path):
+    macro, echo, out = _prep_fixture(tmp_path)
+    run_peak_window_postprocess(PeakWindowPostprocessConfig(
+        macro_dir=macro, echo_dir=echo, output_dir=out, window_mode="global-periodic-common", window_output_layout="continuous-train"
+    ))
+    product = resolve_waveform_product(out, "processed_continuous_train")
+    assert Path(product["waveform_path"]).name == "secondary_peak_global_periodic_continuous_train_processed_waveforms.npy"
+    assert product["shape"] == [2, 300]
+    manifest = pd.read_csv(product["manifest_path"])
+    assert len(manifest) == 2
+
+
+def test_fft_uses_processed_continuous_train(tmp_path: Path):
+    macro, echo, out = _prep_fixture(tmp_path)
+    run_peak_window_postprocess(PeakWindowPostprocessConfig(
+        macro_dir=macro, echo_dir=echo, output_dir=out, window_mode="global-periodic-common", window_output_layout="continuous-train"
+    ))
+    fft_summary = run_fft_postprocessed(FFTExportConfig(
+        postprocess_dir=out, source_product="processed_continuous_train", fft_mode="full", output_bins=1024
+    ))
+    assert fft_summary["source_product"] == "processed_continuous_train"
+    assert fft_summary["source_window_output_layout"] == "continuous-train"
+    assert fft_summary["n_rows"] == 2
+    assert fft_summary["cropped_time_domain"] is False


### PR DESCRIPTION
## Summary
- Isolated `global-periodic-common` output-writing by layout in `run_peak_window_postprocess` so `continuous-train` no longer falls through into period-row/legacy alias saves.
- Added explicit continuous-train summary fields (`n_rows`, `n_periods_total`, `train_samples`, `source_layout`, method metadata, and processing params) and ensured `waveform_products.json` is written before return.
- Added optional legacy alias controls:
  - `write_legacy_aliases` (default false)
  - `strict_legacy_aliases` (default false)
  - CLI flags `--write-legacy-aliases/--no-write-legacy-aliases` and `--strict-legacy-aliases/--no-strict-legacy-aliases`
- Updated tests to verify:
  - continuous-train canonical outputs succeed without legacy aliases
  - continuous-train summary shape/count fields are consistent
  - `resolve_waveform_product(..., "processed_continuous_train")` resolves correctly
  - FFT using `--source-product processed_continuous_train` reports expected source metadata

## Why
Continuous-train postprocess should succeed using canonical continuous-train artifacts and registry products, without requiring ambiguous legacy alias files.

## Validation
- `pytest -q tests/test_postprocess_peak_windows.py tests/test_fft_export.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17a123f13083229cff13b1fe5ce8c8)