### PR TITLE
Fix dataset config YAML serialization

### DIFF
--- a/src/echopress/core/config_io.py
+++ b/src/echopress/core/config_io.py
@@ -37,7 +37,20 @@ def merge_config(
     return resolved
 
 
+def make_yaml_safe(obj: Any) -> Any:
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, dict):
+        return {str(k): make_yaml_safe(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [make_yaml_safe(v) for v in obj]
+    if isinstance(obj, tuple):
+        return [make_yaml_safe(v) for v in obj]
+    return obj
+
+
 def write_resolved_config(config: dict[str, Any], path: Path) -> None:
     yaml = _require_yaml()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    safe = make_yaml_safe(config)
+    path.write_text(yaml.safe_dump(safe, sort_keys=False), encoding="utf-8")

--- a/src/echopress/ml/dataset.py
+++ b/src/echopress/ml/dataset.py
@@ -28,6 +28,10 @@ def _resolve_config(cfg: PressureDatasetConfig) -> dict[str, Any]:
         if k in rcfg.get("dataset", {}) and rcfg.get(k) is None:
             rcfg[k] = rcfg["dataset"][k]
     rcfg["fft_dir"] = str(cfg.fft_dir); rcfg["output_dir"] = str(cfg.output_dir)
+    if cfg.config is not None:
+        rcfg["config"] = str(cfg.config)
+    else:
+        rcfg.pop("config", None)
     return rcfg
 
 def build_pressure_dataset(cfg: PressureDatasetConfig) -> dict[str, Any]:

--- a/tests/test_ml_dataset.py
+++ b/tests/test_ml_dataset.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from echopress.core.config_io import load_yaml_defaults
+from echopress.ml.dataset import PressureDatasetConfig, build_pressure_dataset
+
+
+def test_build_pressure_dataset_with_path_config_writes_outputs(tmp_path: Path):
+    pytest.importorskip("yaml", reason="PyYAML not installed")
+    fft_dir = tmp_path / "fft"
+    fft_dir.mkdir()
+    output_dir = tmp_path / "dataset"
+    config_path = tmp_path / "pressure_regression_dataset_config.yml"
+
+    n_samples = 10
+    n_features = 8
+    pd.DataFrame(
+        {
+            "file": [f"sample_{idx}.npy" for idx in range(n_samples)],
+            "path": [str(fft_dir / f"sample_{idx}.npy") for idx in range(n_samples)],
+            "pressure_value": np.linspace(1.0, 10.0, n_samples),
+        }
+    ).to_csv(fft_dir / "fft_manifest.csv", index=False)
+    np.save(fft_dir / "fft_relative_db.npy", np.arange(n_samples * n_features, dtype=float).reshape(n_samples, n_features))
+    np.save(fft_dir / "fft_cycles_per_window.npy", np.linspace(1.0, 8.0, n_features))
+
+    config_path.write_text(
+        "\n".join(
+            [
+                "dataset:",
+                "  feature_source: fft_relative_db",
+                "  target_column: pressure_value",
+                "  freq_min_cycles_per_window: 1.0",
+                "  freq_max_cycles_per_window: 8.0",
+                "  bin_average: 1",
+                "  require_finite: true",
+                "  drop_nan_targets: true",
+                "split:",
+                "  method: random",
+                "  train_frac: 0.6",
+                "  val_frac: 0.2",
+                "  random_seed: 7",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    build_pressure_dataset(PressureDatasetConfig(fft_dir=fft_dir, output_dir=output_dir, config=config_path))
+
+    expected_outputs = {
+        "X.npy",
+        "y.npy",
+        "split.json",
+        "sample_manifest.csv",
+        "dataset_summary.json",
+    }
+    assert expected_outputs.issubset({path.name for path in output_dir.iterdir()})
+
+    resolved = load_yaml_defaults(output_dir / "dataset_config.resolved.yml")
+    assert resolved["config"] == str(config_path)
+    assert isinstance(resolved["config"], str)


### PR DESCRIPTION
### Motivation
- Writing resolved configs crashed on Windows because `yaml.safe_dump()` could not serialize `Path`/`WindowsPath` objects coming from merged CLI/dataclass values. 
- The pressure dataset resolver left `config` as a `Path` which triggered the failure when `write_resolved_config()` attempted to dump the mapping. 

### Description
- Add a recursive sanitizer `make_yaml_safe()` in `src/echopress/core/config_io.py` that converts `Path` objects to strings and normalizes dict/list/tuple contents before YAML dumping. 
- Update `write_resolved_config()` to call `make_yaml_safe()` and dump the sanitized object. 
- Normalize dataset config resolution in `src/echopress/ml/dataset.py::_resolve_config()` to stringify `fft_dir`/`output_dir` and to stringify `config` when provided (or remove the key when absent). 
- Add `tests/test_ml_dataset.py` covering `PressureDatasetConfig(config=Path(...))` to assert expected output artifacts are written and that the resolved YAML contains `config` as a string. 

### Testing
- Ran `pytest -q tests/test_config.py tests/test_ml_dataset.py` and the tests completed successfully. 
- Ran the full test suite with `pytest -q` and all tests passed. 
- The new regression test verifies that `build_pressure_dataset(PressureDatasetConfig(config=Path(...)))` writes `X.npy`, `y.npy`, `split.json`, `sample_manifest.csv`, and `dataset_summary.json`, and that `dataset_config.resolved.yml` contains a string `config` value.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18ff6b62fc83228b9c869b28804d1f)