### PR TITLE
Fix eval-pressure-regressor: pass user_yaml_path and use split-specific outputs

### DIFF
--- a/src/echopress/ml/evaluate.py
+++ b/src/echopress/ml/evaluate.py
@@ -17,7 +17,7 @@ def run_evaluate(cfg: PressureEvalConfig):
     import tensorflow as tf
     ds=Path(cfg.dataset_dir); md=Path(cfg.model_dir); out=md/f"eval_{cfg.split}"; out.mkdir(parents=True, exist_ok=True)
     default_yml = Path(__file__).resolve().parents[3] / "configs" / "pressure_regression.default.yml"
-    rcfg = merge_config(default_yaml_path=default_yml, cli_values={"dataset_dir": str(ds), "model_dir": str(md), "split": cfg.split})
+    rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=None, cli_values={"dataset_dir": str(ds), "model_dir": str(md), "split": cfg.split})
     write_resolved_config(rcfg, out / "eval_config.resolved.yml")
     X=np.load(ds/"X.npy"); y=np.load(ds/"y.npy"); split=json.loads((ds/"split.json").read_text())
     idx=np.array(split[cfg.split]); prep=json.loads((md/"preprocessing.json").read_text())
@@ -26,8 +26,8 @@ def run_evaluate(cfg: PressureEvalConfig):
     pred=(model.predict(Xs, verbose=0).reshape(-1)*prep["y_std"]+prep["y_mean"])
     yt=y[idx]; resid=pred-yt
     mae=float(np.mean(np.abs(resid))); rmse=float(np.sqrt(np.mean(resid**2))); bias=float(np.mean(resid)); med=float(np.median(np.abs(resid))); mmax=float(np.max(np.abs(resid))); r2=float(1.0 - np.sum(resid**2)/max(np.sum((yt-np.mean(yt))**2),1e-12))
-    (out/"metrics_test.json").write_text(json.dumps({"mae":mae,"rmse":rmse,"r2":r2,"bias":bias,"median_abs_error":med,"max_abs_error":mmax,"n_test":int(len(idx))}, indent=2), encoding="utf-8")
-    pd.DataFrame({"y_true":yt,"y_pred":pred,"residual":resid}).to_csv(out/"predictions_test.csv", index=False)
+    (out/f"metrics_{cfg.split}.json").write_text(json.dumps({"mae":mae,"rmse":rmse,"r2":r2,"bias":bias,"median_abs_error":med,"max_abs_error":mmax,"n_test":int(len(idx))}, indent=2), encoding="utf-8")
+    pd.DataFrame({"y_true":yt,"y_pred":pred,"residual":resid}).to_csv(out/f"predictions_{cfg.split}.csv", index=False)
     plt.figure(); plt.scatter(yt,pred,s=10); plt.xlabel("true"); plt.ylabel("pred"); plt.tight_layout(); plt.savefig(out/"prediction_vs_true.png", dpi=170); plt.close()
     plt.figure(); plt.scatter(yt,resid,s=10); plt.xlabel("pressure_true"); plt.ylabel("residual"); plt.tight_layout(); plt.savefig(out/"residual_vs_pressure.png", dpi=170); plt.close()
     plt.figure(); plt.hist(resid,bins=30); plt.xlabel("residual"); plt.ylabel("count"); plt.tight_layout(); plt.savefig(out/"residual_hist.png", dpi=170); plt.close()

--- a/tests/test_ml_evaluate.py
+++ b/tests/test_ml_evaluate.py
@@ -1,0 +1,54 @@
+import json
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from echopress.ml.evaluate import PressureEvalConfig, run_evaluate
+
+
+pytest.importorskip("yaml")
+
+
+class _FakeModel:
+    def predict(self, xs, verbose=0):
+        return xs[:, :1]
+
+
+def test_run_evaluate_writes_split_specific_outputs(tmp_path, monkeypatch):
+    def load_model(path):
+        assert path.name == "model_best.keras"
+        return _FakeModel()
+
+    tf = types.ModuleType("tensorflow")
+    tf.keras = types.SimpleNamespace(models=types.SimpleNamespace(load_model=load_model))
+    monkeypatch.setitem(sys.modules, "tensorflow", tf)
+
+    dataset_dir = tmp_path / "dataset"
+    model_dir = tmp_path / "model"
+    dataset_dir.mkdir()
+    model_dir.mkdir()
+
+    np.save(dataset_dir / "X.npy", np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]]))
+    np.save(dataset_dir / "y.npy", np.array([0.0, 1.0, 1.5, 3.0, 4.5, 5.0]))
+    (dataset_dir / "split.json").write_text(
+        json.dumps({"train": [0, 1], "val": [2, 3], "test": [4, 5]}),
+        encoding="utf-8",
+    )
+    (model_dir / "preprocessing.json").write_text(
+        json.dumps({"x_mean": [0.0], "x_std": [1.0], "y_mean": 0.0, "y_std": 1.0}),
+        encoding="utf-8",
+    )
+
+    for split in ("train", "val", "test"):
+        run_evaluate(PressureEvalConfig(dataset_dir=dataset_dir, model_dir=model_dir, split=split))
+
+        eval_dir = model_dir / f"eval_{split}"
+        assert (eval_dir / f"metrics_{split}.json").exists()
+        assert (eval_dir / f"predictions_{split}.csv").exists()
+
+    assert not (model_dir / "eval_train" / "metrics_test.json").exists()
+    assert not (model_dir / "eval_train" / "predictions_test.csv").exists()
+    assert not (model_dir / "eval_val" / "metrics_test.json").exists()
+    assert not (model_dir / "eval_val" / "predictions_test.csv").exists()


### PR DESCRIPTION
### Motivation
- `merge_config` now requires a `user_yaml_path` parameter and calling code must supply it (or `None`) to avoid signature errors.
- Evaluation output files were hard-coded to `*_test.*`, causing incorrect filenames when evaluating `train` or `val` splits.
- Tests should verify outputs are created per-split and that legacy `*_test` aliases are not created for non-test splits.

### Description
- Pass `user_yaml_path=None` into `merge_config` when resolving the eval config in `src/echopress/ml/evaluate.py`.
- Replace hard-coded `metrics_test.json` and `predictions_test.csv` with `metrics_{cfg.split}.json` and `predictions_{cfg.split}.csv` so outputs are split-specific.
- Add `tests/test_ml_evaluate.py` which mocks a minimal TensorFlow model and asserts that `eval_{split}/metrics_{split}.json` and `eval_{split}/predictions_{split}.csv` are written for `train`, `val`, and `test`, and that `*_test` aliases are not produced for non-test splits.

### Testing
- Ran `pytest -q tests/test_ml_evaluate.py` and the new test passed.
- Ran `pytest -q tests/test_config.py tests/test_ml_evaluate.py` and both tests passed.
- Ran the full test suite with `pytest -q` and all tests passed (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1910b824348322a995e52bedfd62c0)