### PR TITLE
Add CLI --set dotted YAML overrides for pressure-regression commands

### DIFF
--- a/src/echopress/cli.py
+++ b/src/echopress/cli.py
@@ -24,6 +24,7 @@ from .core.echo_peaks import EchoPeakConfig, run_echo_peak_detection
 from .core.align_cleaner import AlignCleanerConfig, run_align_clean
 from .core.peak_window_postprocess import PeakWindowPostprocessConfig, run_peak_window_postprocess
 from .core.fft_export import FFTExportConfig, run_fft_postprocessed
+from .core.config_io import apply_override, parse_override_value
 from .core.qc_plots import QCPlotConfig, run_qc_plot
 from .core.rmcpe import RMCPEConfig, run_rmcpe
 from .core.tables import File2PressureMap, OscFiles, Signals, export_tables
@@ -43,25 +44,10 @@ SEGMENTATION_MODES = ("none", "rmcpe-tciml", "macro-windows")
 
 
 def _parse_override_value(raw: str) -> object:
-    lower = raw.lower()
-    if lower in {"true", "false"}:
-        return lower == "true"
-    if lower in {"null", "none"}:
-        return None
     try:
-        return int(raw)
-    except ValueError:
-        pass
-    try:
-        return float(raw)
-    except ValueError:
-        pass
-    if raw.startswith("[") or raw.startswith("{"):
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError:
-            raise typer.BadParameter(f"invalid JSON override value: {raw}") from None
-    return raw
+        return parse_override_value(raw)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _ensure_path(settings: Settings, keys: List[str]) -> None:
@@ -86,14 +72,10 @@ def _ensure_path(settings: Settings, keys: List[str]) -> None:
 
 
 def _apply_override(data: Dict[str, object], keys: List[str], value: object) -> None:
-    target = data
-    for key in keys[:-1]:
-        existing = target.get(key)
-        if not isinstance(existing, dict):
-            existing = {}
-            target[key] = existing
-        target = existing
-    target[keys[-1]] = value
+    try:
+        apply_override(data, keys, value)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _apply_overrides(settings: Settings, overrides: List[str]) -> Settings:
@@ -1161,9 +1143,10 @@ def build_pressure_regression_dataset(
     fft_dir: Path = typer.Option(..., "--fft-dir", file_okay=False, dir_okay=True),
     output_dir: Path = typer.Option(..., "--output-dir", file_okay=False, dir_okay=True),
     config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+    set_overrides: List[str] = typer.Option([], "--set"),
 ) -> None:
     summary = build_pressure_dataset(
-        PressureDatasetConfig(fft_dir=fft_dir, output_dir=output_dir, config=config)
+        PressureDatasetConfig(fft_dir=fft_dir, output_dir=output_dir, config=config, overrides=set_overrides)
     )
     typer.echo(json.dumps(summary, indent=2))
 
@@ -1173,8 +1156,9 @@ def train_pressure_regressor(
     dataset_dir: Path = typer.Option(..., "--dataset-dir", file_okay=False, dir_okay=True),
     output_dir: Path = typer.Option(..., "--output-dir", file_okay=False, dir_okay=True),
     config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+    set_overrides: List[str] = typer.Option([], "--set"),
 ) -> None:
-    run_train(PressureTrainConfig(dataset_dir=dataset_dir, output_dir=output_dir, config=config))
+    run_train(PressureTrainConfig(dataset_dir=dataset_dir, output_dir=output_dir, config=config, overrides=set_overrides))
     typer.echo(json.dumps({"status": "ok", "output_dir": str(output_dir)}, indent=2))
 
 
@@ -1193,11 +1177,12 @@ def train_pressure_baseline(
     fft_dir: Path = typer.Option(..., "--fft-dir", file_okay=False, dir_okay=True),
     output_dir: Path = typer.Option(..., "--output-dir", file_okay=False, dir_okay=True),
     config: Optional[Path] = typer.Option(None, "--config", dir_okay=False, file_okay=True),
+    set_overrides: List[str] = typer.Option([], "--set"),
 ) -> None:
     dataset_dir = output_dir / "pressure_regression_dataset"
     model_dir = output_dir / "pressure_regressor_tf"
-    build_pressure_dataset(PressureDatasetConfig(fft_dir=fft_dir, output_dir=dataset_dir, config=config))
-    run_train(PressureTrainConfig(dataset_dir=dataset_dir, output_dir=model_dir, config=config))
+    build_pressure_dataset(PressureDatasetConfig(fft_dir=fft_dir, output_dir=dataset_dir, config=config, overrides=set_overrides))
+    run_train(PressureTrainConfig(dataset_dir=dataset_dir, output_dir=model_dir, config=config, overrides=set_overrides))
     run_evaluate(PressureEvalConfig(dataset_dir=dataset_dir, model_dir=model_dir, split="test"))
     typer.echo(json.dumps({"status": "ok", "dataset_dir": str(dataset_dir), "model_dir": str(model_dir)}, indent=2))
 

--- a/src/echopress/core/config_io.py
+++ b/src/echopress/core/config_io.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import copy
+import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 
 def _require_yaml() -> Any:
@@ -22,6 +24,63 @@ def load_yaml_defaults(path: Path) -> dict[str, Any]:
     if not isinstance(loaded, dict):
         raise ValueError(f"Expected mapping in YAML config: {path}")
     return loaded
+
+
+def parse_override_value(raw: str) -> Any:
+    """Parse a command-line override value into a Python object.
+
+    Values intentionally accept JSON-ish scalars and containers so CLI users can
+    write overrides such as ``--set model.hidden_units=[32,16]`` while keeping
+    plain strings unchanged.
+    """
+    lower = raw.lower()
+    if lower in {"true", "false"}:
+        return lower == "true"
+    if lower in {"null", "none"}:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    if raw.startswith("[") or raw.startswith("{"):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSON override value: {raw}") from exc
+    return raw
+
+
+def apply_override(data: dict[str, Any], keys: Sequence[str], value: Any) -> None:
+    """Apply a parsed value to a nested mapping using dotted-key components."""
+    if not keys or any(key == "" for key in keys):
+        raise ValueError("override key cannot be empty")
+    target = data
+    for key in keys[:-1]:
+        existing = target.get(key)
+        if not isinstance(existing, dict):
+            existing = {}
+            target[key] = existing
+        target = existing
+    target[keys[-1]] = value
+
+
+def apply_dotted_overrides(data: dict[str, Any], overrides: Sequence[str] | None) -> dict[str, Any]:
+    """Return a copy of *data* with ``section.key=value`` overrides applied."""
+    resolved = copy.deepcopy(data)
+    if not overrides:
+        return resolved
+    for override in overrides:
+        if "=" not in override:
+            raise ValueError("overrides must be of the form --set section.key=value")
+        key, raw_value = override.split("=", 1)
+        keys = key.split(".")
+        value = parse_override_value(raw_value)
+        apply_override(resolved, keys, value)
+    return resolved
 
 
 def merge_config(

--- a/src/echopress/ml/dataset.py
+++ b/src/echopress/ml/dataset.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 import numpy as np
 import pandas as pd
-from echopress.core.config_io import merge_config, write_resolved_config
+from echopress.core.config_io import apply_dotted_overrides, merge_config, write_resolved_config
 from .splits import make_pressure_splits
 
 @dataclass(frozen=True)
@@ -20,13 +20,16 @@ class PressureDatasetConfig:
     bin_average: Optional[int] = None
     require_finite: Optional[bool] = None
     drop_nan_targets: Optional[bool] = None
+    overrides: Optional[List[str]] = None
 
 def _resolve_config(cfg: PressureDatasetConfig) -> dict[str, Any]:
     default_yml = Path(__file__).resolve().parents[3] / "configs" / "pressure_regression.default.yml"
     rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=cfg.config, cli_values=asdict(cfg))
+    rcfg = apply_dotted_overrides(rcfg, cfg.overrides)
     for k in ("feature_source","target_column","freq_min_cycles_per_window","freq_max_cycles_per_window","bin_average","require_finite","drop_nan_targets"):
         if k in rcfg.get("dataset", {}) and rcfg.get(k) is None:
             rcfg[k] = rcfg["dataset"][k]
+    rcfg.pop("overrides", None)
     rcfg["fft_dir"] = str(cfg.fft_dir); rcfg["output_dir"] = str(cfg.output_dir)
     if cfg.config is not None:
         rcfg["config"] = str(cfg.config)

--- a/src/echopress/ml/train.py
+++ b/src/echopress/ml/train.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 import numpy as np, pandas as pd
-from echopress.core.config_io import merge_config, write_resolved_config
+from echopress.core.config_io import apply_dotted_overrides, merge_config, write_resolved_config
 from .models import build_model
 from .preprocess import fit_transform_preprocess
 
@@ -13,6 +13,7 @@ class PressureTrainConfig:
     dataset_dir: Path
     output_dir: Path
     config: Optional[Path] = None
+    overrides: Optional[List[str]] = None
 
 def run_train(cfg: PressureTrainConfig):
     try:
@@ -21,6 +22,7 @@ def run_train(cfg: PressureTrainConfig):
         raise RuntimeError("TensorFlow is required. Install with: pip install -r requirements-ml.txt") from exc
     default_yml = Path(__file__).resolve().parents[3] / "configs" / "pressure_regression.default.yml"
     rcfg = merge_config(default_yaml_path=default_yml, user_yaml_path=cfg.config, cli_values={"dataset_dir":str(cfg.dataset_dir),"output_dir":str(cfg.output_dir)})
+    rcfg = apply_dotted_overrides(rcfg, cfg.overrides)
     out=Path(cfg.output_dir); out.mkdir(parents=True, exist_ok=True); write_resolved_config(rcfg, out/"train_config.resolved.yml")
     X=np.load(Path(cfg.dataset_dir)/"X.npy"); y=np.load(Path(cfg.dataset_dir)/"y.npy"); split=json.loads((Path(cfg.dataset_dir)/"split.json").read_text())
     tr,va,te=np.array(split["train"]),np.array(split["val"]),np.array(split["test"])

--- a/tests/test_ml_train_overrides.py
+++ b/tests/test_ml_train_overrides.py
@@ -1,0 +1,133 @@
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+from typer.testing import CliRunner
+
+from echopress.cli import app
+from echopress.core.config_io import load_yaml_defaults, parse_override_value
+
+
+class _FakeHistory:
+    history = {"loss": [1.0], "val_loss": [1.2]}
+
+
+class _FakeModel:
+    def compile(self, **kwargs):
+        self.compile_kwargs = kwargs
+
+    def fit(self, *args, **kwargs):
+        self.fit_kwargs = kwargs
+        return _FakeHistory()
+
+    def save(self, path):
+        Path(path).write_text("fake model", encoding="utf-8")
+
+    def predict(self, X, verbose=0):
+        return np.zeros((len(X), 1), dtype=float)
+
+
+def _install_fake_tensorflow(monkeypatch):
+    class _Adam:
+        def __init__(self, learning_rate):
+            self.learning_rate = learning_rate
+
+    class _RootMeanSquaredError:
+        def __init__(self, name=None):
+            self.name = name
+
+    class _Callback:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    fake_tf = types.SimpleNamespace(
+        keras=types.SimpleNamespace(
+            optimizers=types.SimpleNamespace(Adam=_Adam),
+            metrics=types.SimpleNamespace(RootMeanSquaredError=_RootMeanSquaredError),
+            callbacks=types.SimpleNamespace(
+                EarlyStopping=_Callback,
+                ModelCheckpoint=_Callback,
+                ReduceLROnPlateau=_Callback,
+            ),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "tensorflow", fake_tf)
+
+
+def test_train_pressure_regressor_set_overrides(tmp_path, monkeypatch):
+    pytest.importorskip("yaml", reason="PyYAML not installed")
+    _install_fake_tensorflow(monkeypatch)
+
+    import echopress.ml.train as train_module
+
+    monkeypatch.setattr(train_module, "build_model", lambda input_dim, rcfg: _FakeModel())
+
+    def fake_preprocess(Xtr, Xva, Xte, ytr, yva, yte, config, output_path):
+        output_path.write_text('{"fake": true}', encoding="utf-8")
+        return Xtr, Xva, Xte, ytr, yva, yte, {"y_std": 1.0, "y_mean": 0.0}
+
+    monkeypatch.setattr(train_module, "fit_transform_preprocess", fake_preprocess)
+
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    np.save(dataset_dir / "X.npy", np.arange(24, dtype=np.float32).reshape(6, 4))
+    np.save(dataset_dir / "y.npy", np.arange(6, dtype=np.float32))
+    (dataset_dir / "split.json").write_text(
+        '{"train": [0, 1, 2, 3], "val": [4], "test": [5]}',
+        encoding="utf-8",
+    )
+
+    base_yaml = tmp_path / "base.yml"
+    base_yaml.write_text(
+        "\n".join(
+            [
+                "model:",
+                "  hidden_units: [256, 128, 64]",
+                "  dropout: 0.1",
+                "train:",
+                "  epochs: 300",
+                "  batch_size: 32",
+                "  verbose: 0",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "model"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "train-pressure-regressor",
+            "--dataset-dir",
+            str(dataset_dir),
+            "--output-dir",
+            str(output_dir),
+            "--config",
+            str(base_yaml),
+            "--set",
+            "model.hidden_units=[32,16]",
+            "--set",
+            "model.dropout=0.8",
+            "--set",
+            "train.epochs=600",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    resolved = load_yaml_defaults(output_dir / "train_config.resolved.yml")
+    assert resolved["model"]["hidden_units"] == [32, 16]
+    assert resolved["model"]["dropout"] == 0.8
+    assert resolved["train"]["epochs"] == 600
+
+
+def test_set_override_types():
+    assert parse_override_value("42") == 42
+    assert parse_override_value("0.125") == 0.125
+    assert parse_override_value("false") is False
+    assert parse_override_value("true") is True
+    assert parse_override_value("[32,16]") == [32, 16]
+    assert parse_override_value("null") is None


### PR DESCRIPTION
### Motivation
- Provide a way to override nested ML config values from the command line (e.g. `model.hidden_units`, `train.epochs`) for pressure-regression commands without editing YAML files or the global `Settings` object.

### Description
- Add shared helpers in `src/echopress/core/config_io.py`: `parse_override_value`, `apply_override`, and `apply_dotted_overrides` to parse JSON-ish scalars/containers and apply dotted keys to nested dicts.
- Wire a `--set` option into CLI commands in `src/echopress/cli.py` for `train-pressure-regressor`, `build-pressure-regression-dataset`, and `train-pressure-baseline`, collecting `List[str]` overrides and forwarding them into ML code.
- Extend `PressureTrainConfig` and `PressureDatasetConfig` with an `overrides` field and apply overrides after `merge_config(...)` via `apply_dotted_overrides` in `src/echopress/ml/train.py` and `src/echopress/ml/dataset.py`, and write the final resolved YAML to `train_config.resolved.yml` (and dataset resolved file remains written) so users can confirm overrides took effect.
- Add tests `tests/test_ml_train_overrides.py` that verify `--set` correctly overrides list/int/float/bool/null values and that `train_config.resolved.yml` contains the overridden values.

### Testing
- Added `tests/test_ml_train_overrides.py` covering override parsing and CLI use of `--set` for `train-pressure-regressor` and ran `pytest -q` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f9fd2b9c8322afbdd4e542909b48)